### PR TITLE
plugin_dir option for terraform init

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ The init command supports the following options passed as keyword arguments:
 * `backend_config`: a map of backend specific configuration parameters.
 * `no_color`: whether or not the output from the command should be in color;
   defaults to `false`.
+* `plugin_dir`: directory containing plugin binaries. Overrides all default;
+  search paths for plugins and prevents the automatic installation of plugins.
 
 
 ### RubyTerraform::Commands::Get

--- a/lib/ruby_terraform/commands/init.rb
+++ b/lib/ruby_terraform/commands/init.rb
@@ -11,6 +11,7 @@ module RubyTerraform
         backend_config = opts[:backend_config] || {}
         source = opts[:from_module]
         path = opts[:path]
+        plugin_dir = opts[:plugin_dir]
 
         builder = builder
             .with_subcommand('init') do |sub|
@@ -18,6 +19,7 @@ module RubyTerraform
               sub = sub.with_option('-get', get) unless get.nil?
               sub = sub.with_option('-from-module', source) if source
               sub = sub.with_flag('-no-color') if no_color
+              sub = sub.with_option('-plugin-dir', plugin_dir) unless plugin_dir.nil?
               backend_config.each do |key, value|
                 sub = sub.with_option(
                     '-backend-config',

--- a/spec/ruby_terraform/commands/init_spec.rb
+++ b/spec/ruby_terraform/commands/init_spec.rb
@@ -67,6 +67,17 @@ describe RubyTerraform::Commands::Init do
         from_module: 'some/module/source')
   end
 
+  it 'uses the supplied plugin directory when provided' do
+    command = RubyTerraform::Commands::Init.new(binary: 'terraform')
+
+    expect(Open4).to(
+      receive(:spawn)
+          .with('terraform init -plugin-dir=some/plugin/directory', any_args))
+
+    command.execute(
+      plugin_dir: 'some/plugin/directory')
+  end
+
   it 'adds the supplied path when provided' do
     command = RubyTerraform::Commands::Init.new(binary: 'terraform')
 


### PR DESCRIPTION
added plugin_dir for the init command of terraform in order to prevent downloading plugins for each new configuration scope.
Updated init.rb, README and according rspec test