### PR TITLE
Require stringio in output.rb to avoid error

### DIFF
--- a/lib/ruby_terraform/commands/output.rb
+++ b/lib/ruby_terraform/commands/output.rb
@@ -1,4 +1,5 @@
 require 'lino'
+require 'stringio'
 require_relative 'base'
 
 module RubyTerraform


### PR DESCRIPTION
Hey, Toby,
While using the output class I encountered this error:

`~/.rvm/gems/ruby-2.1.0/gems/ruby-terraform-0.11.2/lib/ruby_terraform/commands/output.rb:8:in 'stdout': uninitialized constant RubyTerraform::Commands::Output::StringIO (NameError)`

Adding a require statement for stringio appears to fix it. The tests still pass. 

Very helpful gem. Thanks!