### PR TITLE
Change STDOUT and STDERR to $stdout and $stderr respectively

### DIFF
--- a/lib/ruby_terraform/commands/base.rb
+++ b/lib/ruby_terraform/commands/base.rb
@@ -14,11 +14,11 @@ module RubyTerraform
       end
 
       def stdout
-        STDOUT
+        $stdout
       end
 
       def stderr
-        STDERR
+        $stderr
       end
 
       def execute(opts = {})


### PR DESCRIPTION
Use the variables, rather than the constants to enable more easily
changing these for the duration of running the Terraform command. I'm
hoping this will more easily enable capturing the output.