### PR TITLE
Allow multiple -var-file options

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ RubyTerraform::Commands::Plan.new.execute(
 The plan command supports the following options passed as keyword arguments:
 * `directory`: the directory containing terraform configuration; required.
 * `vars`: a map of vars to be passed in to the terraform configuration.
-* `var_file`: an array of files holding list of variables with their values (in terraform format) to be passed to terraform.
+* `var_file`: a file holding list of variables with their values (in terraform format) to be passed to terraform.
+* `var_files`: same that var_file but in array format, to allow multiple var files. 
 * `state`: the path to the state file in which to store state; defaults to
   terraform.tfstate in the working directory or the remote state if configured.
 * `plan`: the name of the in which to save the generated plan.
@@ -159,7 +160,8 @@ RubyTerraform::Commands::Apply.new.execute(
 The apply command supports the following options passed as keyword arguments:
 * `directory`: the directory containing terraform configuration; required.
 * `vars`: a map of vars to be passed in to the terraform configuration.
-* `var_file`: an array of files holding list of variables with their values (in terraform format) to be passed to terraform
+* `var_file`: a file holding list of variables with their values (in terraform format) to be passed to terraform.
+* `var_files`: same that var_file but in array format, to allow multiple var files. 
 * `state`: the path to the state file in which to store state; defaults to
   terraform.tfstate in the working directory or the remote state if configured.
 * `backup`: the path to the backup file in which to store the state backup.
@@ -193,7 +195,8 @@ RubyTerraform::Commands::Destroy.new.execute(
 The destroy command supports the following options passed as keyword arguments:
 * `directory`: the directory containing terraform configuration; required.
 * `vars`: a map of vars to be passed in to the terraform configuration.
-* `var_file`: an array of files holding list of variables with their values (in terraform format) to be passed to terraform
+* `var_file`: a file holding list of variables with their values (in terraform format) to be passed to terraform.
+* `var_files`: same that var_file but in array format, to allow multiple var files. 
 * `state`: the path to the state file containing the current state; defaults to
   terraform.tfstate in the working directory or the remote state if configured.
 * `force`: if `true`, the command destroys without prompting the user to confirm

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ RubyTerraform::Commands::Plan.new.execute(
 The plan command supports the following options passed as keyword arguments:
 * `directory`: the directory containing terraform configuration; required.
 * `vars`: a map of vars to be passed in to the terraform configuration.
-* `var_file`: a file holding list of variables with their values (in terraform format) to be passed to terraform.
+* `var_file`: an array of files holding list of variables with their values (in terraform format) to be passed to terraform.
 * `state`: the path to the state file in which to store state; defaults to
   terraform.tfstate in the working directory or the remote state if configured.
 * `plan`: the name of the in which to save the generated plan.
@@ -159,7 +159,7 @@ RubyTerraform::Commands::Apply.new.execute(
 The apply command supports the following options passed as keyword arguments:
 * `directory`: the directory containing terraform configuration; required.
 * `vars`: a map of vars to be passed in to the terraform configuration.
-* `var_file`: a file holding list of variables with their values (in terraform format) to be passed to terraform
+* `var_file`: an array of files holding list of variables with their values (in terraform format) to be passed to terraform
 * `state`: the path to the state file in which to store state; defaults to
   terraform.tfstate in the working directory or the remote state if configured.
 * `backup`: the path to the backup file in which to store the state backup.
@@ -193,7 +193,7 @@ RubyTerraform::Commands::Destroy.new.execute(
 The destroy command supports the following options passed as keyword arguments:
 * `directory`: the directory containing terraform configuration; required.
 * `vars`: a map of vars to be passed in to the terraform configuration.
-* `var_file`: a file holding list of variables with their values (in terraform format) to be passed to terraform
+* `var_file`: an array of files holding list of variables with their values (in terraform format) to be passed to terraform
 * `state`: the path to the state file containing the current state; defaults to
   terraform.tfstate in the working directory or the remote state if configured.
 * `force`: if `true`, the command destroys without prompting the user to confirm

--- a/lib/ruby_terraform/commands/apply.rb
+++ b/lib/ruby_terraform/commands/apply.rb
@@ -7,7 +7,8 @@ module RubyTerraform
       def configure_command(builder, opts)
         directory = opts[:directory]
         vars = opts[:vars] || {}
-        var_file = opts[:var_file].kind_of?(String) ? opts[:var_file].lines : opts[:var_file] || []
+        var_file = opts[:var_file]
+        var_files = opts[:var_files] || []
         state = opts[:state]
         input = opts[:input]
         auto_approve = opts[:auto_approve]
@@ -20,7 +21,8 @@ module RubyTerraform
               vars.each do |key, value|
                 sub = sub.with_option('-var', "'#{key}=#{value}'", separator: ' ')
               end
-              var_file.each do |file|
+              sub = sub.with_option('-var-file', var_file) if var_file
+              var_files.each do |file|
                 sub = sub.with_option('-var-file', file)
               end
               sub = sub.with_option('-state', state) if state

--- a/lib/ruby_terraform/commands/apply.rb
+++ b/lib/ruby_terraform/commands/apply.rb
@@ -7,7 +7,7 @@ module RubyTerraform
       def configure_command(builder, opts)
         directory = opts[:directory]
         vars = opts[:vars] || {}
-        var_file = opts[:var_file]
+        var_file = opts[:var_file].kind_of?(String) ? opts[:var_file].lines : opts[:var_file] || []
         state = opts[:state]
         input = opts[:input]
         auto_approve = opts[:auto_approve]
@@ -20,7 +20,9 @@ module RubyTerraform
               vars.each do |key, value|
                 sub = sub.with_option('-var', "'#{key}=#{value}'", separator: ' ')
               end
-              sub = sub.with_option('-var-file', var_file) if var_file
+              var_file.each do |file|
+                sub = sub.with_option('-var-file', file)
+              end
               sub = sub.with_option('-state', state) if state
               sub = sub.with_option('-input', input) if input
               sub = sub.with_option('-auto-approve', auto_approve) unless auto_approve.nil?

--- a/lib/ruby_terraform/commands/destroy.rb
+++ b/lib/ruby_terraform/commands/destroy.rb
@@ -7,7 +7,8 @@ module RubyTerraform
       def configure_command(builder, opts)
         directory = opts[:directory]
         vars = opts[:vars] || {}
-        var_file = opts[:var_file].kind_of?(String) ? opts[:var_file].lines : opts[:var_file] || []
+        var_file = opts[:var_file]
+        var_files = opts[:var_files] || []
         state = opts[:state]
         force = opts[:force]
         no_backup = opts[:no_backup]
@@ -19,7 +20,8 @@ module RubyTerraform
               vars.each do |key, value|
                 sub = sub.with_option('-var', "'#{key}=#{value}'", separator: ' ')
               end
-              var_file.each do |file|
+              sub = sub.with_option('-var-file', var_file) if var_file
+              var_files.each do |file|
                 sub = sub.with_option('-var-file', file)
               end
               sub = sub.with_option('-state', state) if state

--- a/lib/ruby_terraform/commands/destroy.rb
+++ b/lib/ruby_terraform/commands/destroy.rb
@@ -7,7 +7,7 @@ module RubyTerraform
       def configure_command(builder, opts)
         directory = opts[:directory]
         vars = opts[:vars] || {}
-        var_file = opts[:var_file]
+        var_file = opts[:var_file].kind_of?(String) ? opts[:var_file].lines : opts[:var_file] || []
         state = opts[:state]
         force = opts[:force]
         no_backup = opts[:no_backup]
@@ -19,7 +19,9 @@ module RubyTerraform
               vars.each do |key, value|
                 sub = sub.with_option('-var', "'#{key}=#{value}'", separator: ' ')
               end
-              sub = sub.with_option('-var-file', var_file) if var_file
+              var_file.each do |file|
+                sub = sub.with_option('-var-file', file)
+              end
               sub = sub.with_option('-state', state) if state
               sub = sub.with_option('-backup', backup) if backup
               sub = sub.with_flag('-no-color') if no_color

--- a/lib/ruby_terraform/commands/plan.rb
+++ b/lib/ruby_terraform/commands/plan.rb
@@ -7,7 +7,8 @@ module RubyTerraform
       def configure_command(builder, opts)
         directory = opts[:directory]
         vars = opts[:vars] || {}
-        var_file = opts[:var_file].kind_of?(String) ? opts[:var_file].lines : opts[:var_file] || []
+        var_file = opts[:var_file]
+        var_files = opts[:var_files] || []
         state = opts[:state]
         plan = opts[:plan]
         input = opts[:input]
@@ -19,7 +20,8 @@ module RubyTerraform
               vars.each do |key, value|
                 sub = sub.with_option('-var', "'#{key}=#{value}'", separator: ' ')
               end
-              var_file.each do |file|
+              sub = sub.with_option('-var-file', var_file) if var_file
+              var_files.each do |file|
                 sub = sub.with_option('-var-file', file)
               end
               sub = sub.with_option('-state', state) if state

--- a/lib/ruby_terraform/commands/plan.rb
+++ b/lib/ruby_terraform/commands/plan.rb
@@ -7,7 +7,7 @@ module RubyTerraform
       def configure_command(builder, opts)
         directory = opts[:directory]
         vars = opts[:vars] || {}
-        var_file = opts[:var_file]
+        var_file = opts[:var_file].kind_of?(String) ? opts[:var_file].lines : opts[:var_file] || []
         state = opts[:state]
         plan = opts[:plan]
         input = opts[:input]
@@ -19,7 +19,9 @@ module RubyTerraform
               vars.each do |key, value|
                 sub = sub.with_option('-var', "'#{key}=#{value}'", separator: ' ')
               end
-              sub = sub.with_option('-var-file', var_file) if var_file
+              var_file.each do |file|
+                sub = sub.with_option('-var-file', file)
+              end
               sub = sub.with_option('-state', state) if state
               sub = sub.with_option('-out', plan) if plan
               sub = sub.with_option('-input', input) if input

--- a/lib/ruby_terraform/commands/refresh.rb
+++ b/lib/ruby_terraform/commands/refresh.rb
@@ -7,7 +7,7 @@ module RubyTerraform
       def configure_command(builder, opts)
         directory = opts[:directory]
         vars = opts[:vars] || {}
-        var_file = opts[:var_file]
+        var_file = opts[:var_file].kind_of?(String) ? opts[:var_file].lines : opts[:var_file] || []
         state = opts[:state]
         refresh = opts[:refresh]
         input = opts[:input]
@@ -20,7 +20,9 @@ module RubyTerraform
               vars.each do |key, value|
                 sub = sub.with_option('-var', "'#{key}=#{value}'", separator: ' ')
               end
-              sub = sub.with_option('-var-file', var_file) if var_file
+              var_file.each do |file|
+                sub = sub.with_option('-var-file', file)
+              end
               sub = sub.with_option('-state', state) if state
               sub = sub.with_option('-input', input) if input
               sub = sub.with_option('-target', target) if target

--- a/lib/ruby_terraform/commands/refresh.rb
+++ b/lib/ruby_terraform/commands/refresh.rb
@@ -7,7 +7,8 @@ module RubyTerraform
       def configure_command(builder, opts)
         directory = opts[:directory]
         vars = opts[:vars] || {}
-        var_file = opts[:var_file].kind_of?(String) ? opts[:var_file].lines : opts[:var_file] || []
+        var_file = opts[:var_file]
+        var_files = opts[:var_files] || []
         state = opts[:state]
         refresh = opts[:refresh]
         input = opts[:input]
@@ -20,7 +21,8 @@ module RubyTerraform
               vars.each do |key, value|
                 sub = sub.with_option('-var', "'#{key}=#{value}'", separator: ' ')
               end
-              var_file.each do |file|
+              sub = sub.with_option('-var-file', var_file) if var_file
+              var_files.each do |file|
                 sub = sub.with_option('-var-file', file)
               end
               sub = sub.with_option('-state', state) if state

--- a/lib/ruby_terraform/commands/validate.rb
+++ b/lib/ruby_terraform/commands/validate.rb
@@ -7,7 +7,8 @@ module RubyTerraform
       def configure_command(builder, opts)
         directory = opts[:directory]
         vars = opts[:vars] || {}
-        var_file = opts[:var_file].kind_of?(String) ? opts[:var_file].lines : opts[:var_file] || []
+        var_file = opts[:var_file]
+        var_files = opts[:var_files] || []
         state = opts[:state]
         check_variables = opts[:check_variables]
         no_color = opts[:no_color]
@@ -17,7 +18,8 @@ module RubyTerraform
               vars.each do |key, value|
                 sub = sub.with_option('-var', "'#{key}=#{value}'", separator: ' ')
               end
-              var_file.each do |file|
+              sub = sub.with_option('-var-file', var_file) if var_file
+              var_files.each do |file|
                 sub = sub.with_option('-var-file', file)
               end
               sub = sub.with_option('-state', state) if state

--- a/lib/ruby_terraform/commands/validate.rb
+++ b/lib/ruby_terraform/commands/validate.rb
@@ -7,7 +7,7 @@ module RubyTerraform
       def configure_command(builder, opts)
         directory = opts[:directory]
         vars = opts[:vars] || {}
-        var_file = opts[:var_file]
+        var_file = opts[:var_file].kind_of?(String) ? opts[:var_file].lines : opts[:var_file] || []
         state = opts[:state]
         check_variables = opts[:check_variables]
         no_color = opts[:no_color]
@@ -17,7 +17,9 @@ module RubyTerraform
               vars.each do |key, value|
                 sub = sub.with_option('-var', "'#{key}=#{value}'", separator: ' ')
               end
-              sub = sub.with_option('-var-file', var_file) if var_file
+              var_file.each do |file|
+                sub = sub.with_option('-var-file', file)
+              end
               sub = sub.with_option('-state', state) if state
               sub = sub.with_option('-check-variables', check_variables) unless check_variables.nil?
               sub = sub.with_flag('-no-color') if no_color

--- a/spec/ruby_terraform/commands/apply_spec.rb
+++ b/spec/ruby_terraform/commands/apply_spec.rb
@@ -107,6 +107,21 @@ describe RubyTerraform::Commands::Apply do
         var_file: 'some/vars.tfvars')
   end
 
+  it 'adds a var-file option for each supplied var-file' do
+    command = RubyTerraform::Commands::Apply.new(binary: 'terraform')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with("terraform apply -var-file=some/vars1.tfvars -var-file=some/vars2.tfvars some/configuration", any_args))
+
+    command.execute(
+        directory: 'some/configuration',
+        var_file: [ 
+            'some/vars1.tfvars',
+            'some/vars2.tfvars'
+        ])
+  end
+
   it 'passes auto-approve of true when the auto_approve option is true' do
     command = RubyTerraform::Commands::Apply.new(binary: 'terraform')
 

--- a/spec/ruby_terraform/commands/apply_spec.rb
+++ b/spec/ruby_terraform/commands/apply_spec.rb
@@ -107,7 +107,7 @@ describe RubyTerraform::Commands::Apply do
         var_file: 'some/vars.tfvars')
   end
 
-  it 'adds a var-file option for each supplied var-file' do
+  it 'adds a var-file option for each element of var-files array' do
     command = RubyTerraform::Commands::Apply.new(binary: 'terraform')
 
     expect(Open4).to(
@@ -116,7 +116,23 @@ describe RubyTerraform::Commands::Apply do
 
     command.execute(
         directory: 'some/configuration',
-        var_file: [ 
+        var_files: [ 
+            'some/vars1.tfvars',
+            'some/vars2.tfvars'
+        ])
+  end
+
+  it 'ensures that var_file and var_files options work together' do
+    command = RubyTerraform::Commands::Apply.new(binary: 'terraform')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with("terraform apply -var-file=some/vars.tfvars -var-file=some/vars1.tfvars -var-file=some/vars2.tfvars some/configuration", any_args))
+
+    command.execute(
+        directory: 'some/configuration',
+        var_file: 'some/vars.tfvars',
+        var_files: [ 
             'some/vars1.tfvars',
             'some/vars2.tfvars'
         ])

--- a/spec/ruby_terraform/commands/destroy_spec.rb
+++ b/spec/ruby_terraform/commands/destroy_spec.rb
@@ -119,7 +119,7 @@ describe RubyTerraform::Commands::Destroy do
         var_file: 'some/vars.tfvars')
   end
 
-  it 'adds a var-file option for each supplied var-file' do
+  it 'adds a var-file option for each element of var-files array' do
     command = RubyTerraform::Commands::Destroy.new(binary: 'terraform')
 
     expect(Open4).to(
@@ -128,7 +128,23 @@ describe RubyTerraform::Commands::Destroy do
 
     command.execute(
         directory: 'some/configuration',
-        var_file: [ 
+        var_files: [ 
+            'some/vars1.tfvars',
+            'some/vars2.tfvars'
+        ])
+  end
+
+  it 'ensures that var_file and var_files options work together' do
+    command = RubyTerraform::Commands::Destroy.new(binary: 'terraform')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with("terraform destroy -var-file=some/vars.tfvars -var-file=some/vars1.tfvars -var-file=some/vars2.tfvars some/configuration", any_args))
+
+    command.execute(
+        directory: 'some/configuration',
+        var_file: 'some/vars.tfvars',
+        var_files: [ 
             'some/vars1.tfvars',
             'some/vars2.tfvars'
         ])

--- a/spec/ruby_terraform/commands/destroy_spec.rb
+++ b/spec/ruby_terraform/commands/destroy_spec.rb
@@ -118,4 +118,19 @@ describe RubyTerraform::Commands::Destroy do
         directory: 'some/configuration',
         var_file: 'some/vars.tfvars')
   end
+
+  it 'adds a var-file option for each supplied var-file' do
+    command = RubyTerraform::Commands::Destroy.new(binary: 'terraform')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with("terraform destroy -var-file=some/vars1.tfvars -var-file=some/vars2.tfvars some/configuration", any_args))
+
+    command.execute(
+        directory: 'some/configuration',
+        var_file: [ 
+            'some/vars1.tfvars',
+            'some/vars2.tfvars'
+        ])
+  end
 end

--- a/spec/ruby_terraform/commands/plan_spec.rb
+++ b/spec/ruby_terraform/commands/plan_spec.rb
@@ -106,7 +106,7 @@ describe RubyTerraform::Commands::Plan do
         var_file: 'some/vars.tfvars')
   end
 
-  it 'adds a var-file option for each supplied var-file' do
+  it 'adds a var-file option for each element of var-files array' do
     command = RubyTerraform::Commands::Plan.new(binary: 'terraform')
 
     expect(Open4).to(
@@ -115,7 +115,23 @@ describe RubyTerraform::Commands::Plan do
 
     command.execute(
         directory: 'some/configuration',
-        var_file: [ 
+        var_files: [ 
+            'some/vars1.tfvars',
+            'some/vars2.tfvars'
+        ])
+  end
+
+  it 'ensures that var_file and var_files options work together' do
+    command = RubyTerraform::Commands::Plan.new(binary: 'terraform')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with("terraform plan -var-file=some/vars.tfvars -var-file=some/vars1.tfvars -var-file=some/vars2.tfvars some/configuration", any_args))
+
+    command.execute(
+        directory: 'some/configuration',
+        var_file: 'some/vars.tfvars',
+        var_files: [ 
             'some/vars1.tfvars',
             'some/vars2.tfvars'
         ])

--- a/spec/ruby_terraform/commands/plan_spec.rb
+++ b/spec/ruby_terraform/commands/plan_spec.rb
@@ -105,6 +105,22 @@ describe RubyTerraform::Commands::Plan do
         directory: 'some/configuration',
         var_file: 'some/vars.tfvars')
   end
+
+  it 'adds a var-file option for each supplied var-file' do
+    command = RubyTerraform::Commands::Plan.new(binary: 'terraform')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with("terraform plan -var-file=some/vars1.tfvars -var-file=some/vars2.tfvars some/configuration", any_args))
+
+    command.execute(
+        directory: 'some/configuration',
+        var_file: [ 
+            'some/vars1.tfvars',
+            'some/vars2.tfvars'
+        ])
+  end
+
   it 'adds a input option if a input value is provided' do
     command = RubyTerraform::Commands::Plan.new(binary: 'terraform')
 

--- a/spec/ruby_terraform/commands/refresh_spec.rb
+++ b/spec/ruby_terraform/commands/refresh_spec.rb
@@ -70,19 +70,7 @@ describe RubyTerraform::Commands::Refresh do
         no_color: true)
   end
 
-  it 'adds a var-file option if a var file is provided' do
-    command = RubyTerraform::Commands::Refresh.new(binary: 'terraform')
-
-    expect(Open4).to(
-        receive(:spawn)
-            .with("terraform refresh -var-file=some/vars.tfvars some/configuration", any_args))
-
-    command.execute(
-        directory: 'some/configuration',
-        var_file: 'some/vars.tfvars')
-  end
-
-  it 'adds a var-file option for each supplied var-file' do
+  it 'adds a var-file option for each element of var-files array' do
     command = RubyTerraform::Commands::Refresh.new(binary: 'terraform')
 
     expect(Open4).to(
@@ -91,7 +79,23 @@ describe RubyTerraform::Commands::Refresh do
 
     command.execute(
         directory: 'some/configuration',
-        var_file: [ 
+        var_files: [ 
+            'some/vars1.tfvars',
+            'some/vars2.tfvars'
+        ])
+  end
+
+  it 'ensures that var_file and var_files options work together' do
+    command = RubyTerraform::Commands::Refresh.new(binary: 'terraform')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with("terraform refresh -var-file=some/vars.tfvars -var-file=some/vars1.tfvars -var-file=some/vars2.tfvars some/configuration", any_args))
+
+    command.execute(
+        directory: 'some/configuration',
+        var_file: 'some/vars.tfvars',
+        var_files: [ 
             'some/vars1.tfvars',
             'some/vars2.tfvars'
         ])

--- a/spec/ruby_terraform/commands/refresh_spec.rb
+++ b/spec/ruby_terraform/commands/refresh_spec.rb
@@ -81,4 +81,19 @@ describe RubyTerraform::Commands::Refresh do
         directory: 'some/configuration',
         var_file: 'some/vars.tfvars')
   end
+
+  it 'adds a var-file option for each supplied var-file' do
+    command = RubyTerraform::Commands::Refresh.new(binary: 'terraform')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with("terraform refresh -var-file=some/vars1.tfvars -var-file=some/vars2.tfvars some/configuration", any_args))
+
+    command.execute(
+        directory: 'some/configuration',
+        var_file: [ 
+            'some/vars1.tfvars',
+            'some/vars2.tfvars'
+        ])
+  end
 end

--- a/spec/ruby_terraform/commands/validate_spec.rb
+++ b/spec/ruby_terraform/commands/validate_spec.rb
@@ -82,19 +82,7 @@ describe RubyTerraform::Commands::Validate do
         check_variables: false)
   end
 
-  it 'adds a var-file option if a var file is provided' do
-    command = RubyTerraform::Commands::Validate.new(binary: 'terraform')
-
-    expect(Open4).to(
-        receive(:spawn)
-            .with("terraform validate -var-file=some/vars.tfvars some/configuration", any_args))
-
-    command.execute(
-        directory: 'some/configuration',
-        var_file: 'some/vars.tfvars')
-  end
-
-  it 'adds a var-file option for each supplied var-file' do
+  it 'adds a var-file option for each element of var-files array' do
     command = RubyTerraform::Commands::Validate.new(binary: 'terraform')
 
     expect(Open4).to(
@@ -103,7 +91,23 @@ describe RubyTerraform::Commands::Validate do
 
     command.execute(
         directory: 'some/configuration',
-        var_file: [ 
+        var_files: [ 
+            'some/vars1.tfvars',
+            'some/vars2.tfvars'
+        ])
+  end
+
+  it 'ensures that var_file and var_files options work together' do
+    command = RubyTerraform::Commands::Validate.new(binary: 'terraform')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with("terraform validate -var-file=some/vars.tfvars -var-file=some/vars1.tfvars -var-file=some/vars2.tfvars some/configuration", any_args))
+
+    command.execute(
+        directory: 'some/configuration',
+        var_file: 'some/vars.tfvars',
+        var_files: [ 
             'some/vars1.tfvars',
             'some/vars2.tfvars'
         ])

--- a/spec/ruby_terraform/commands/validate_spec.rb
+++ b/spec/ruby_terraform/commands/validate_spec.rb
@@ -93,4 +93,19 @@ describe RubyTerraform::Commands::Validate do
         directory: 'some/configuration',
         var_file: 'some/vars.tfvars')
   end
+
+  it 'adds a var-file option for each supplied var-file' do
+    command = RubyTerraform::Commands::Validate.new(binary: 'terraform')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with("terraform validate -var-file=some/vars1.tfvars -var-file=some/vars2.tfvars some/configuration", any_args))
+
+    command.execute(
+        directory: 'some/configuration',
+        var_file: [ 
+            'some/vars1.tfvars',
+            'some/vars2.tfvars'
+        ])
+  end
 end


### PR DESCRIPTION
Hello!

I would like to add support for multiple -var-file options in apply, plan, destroy, refresh and validate commands. Currently, this gem allows to pass only one var-file, but you can see on [terraform documentation](https://www.terraform.io/docs/commands/apply.html) that this flag can be used multiple times. 

Now an array of files can be passed to support multiple var-file flags. Also, I have ensured that this change is retrocompatible, so you can still pass only one var-file option as a string.

I have added some tests to check that the new feature works keeping all previous tests, which also work =). Documentation has been updated too.

I hope this PR will be useful! Thanks!
  