### PR TITLE
Support -module option for output

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ The output command supports the following options passed as keyword arguments:
   terraform.tfstate in the working directory or the remote state if configured.
 * `no_color`: whether or not the output from the command should be in color;
   defaults to `false`.
+* `module`: the name of a module to retrieve output from.
 
 
 ### RubyTerraform::Commands::RemoteConfig

--- a/lib/ruby_terraform/commands/output.rb
+++ b/lib/ruby_terraform/commands/output.rb
@@ -13,11 +13,13 @@ module RubyTerraform
         name = opts[:name]
         state = opts[:state]
         no_color = opts[:no_color]
+        mod = opts[:module]
 
         builder = builder
             .with_subcommand('output') do |sub|
               sub = sub.with_flag('-no-color') if no_color
               sub = sub.with_option('-state', state) if state
+              sub = sub.with_option('-module', mod) if mod
               sub
             end
         builder = builder.with_argument(name) if name

--- a/spec/ruby_terraform/commands/output_spec.rb
+++ b/spec/ruby_terraform/commands/output_spec.rb
@@ -51,6 +51,16 @@ describe RubyTerraform::Commands::Output do
     command.execute(name: 'important_output')
   end
 
+  it 'passes the provided module name if supplied' do
+    command = RubyTerraform::Commands::Output.new(binary: 'terraform')
+
+    expect(Open4).to(
+      receive(:spawn)
+          .with("terraform output -module=some_module", any_args))
+
+    command.execute(module: 'some_module')
+  end
+
   it 'captures and returns the output of the command directly when no name is supplied' do
     command = RubyTerraform::Commands::Output.new(binary: 'terraform')
 


### PR DESCRIPTION
This lets you get outputs from modules in your code without having to bubble them up to your root module.