### PR TITLE
make apply command return output string

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,16 +70,15 @@ the following ways:
 
 ```ruby
 RubyTerraform.init
-RubyTerraform.init(source: 'some/module/path', path: 'infra/module')
+RubyTerraform.init(from-module: 'some/module/path', path: 'infra/module')
 RubyTerraform::Commands::Init.new.execute
 RubyTerraform::Commands::Init.new.execute(
-    source: 'some/module/path', 
+    from-module: 'some/module/path', 
     path: 'infra/module')
 ```
 
 The init command supports the following options passed as keyword arguments:
-* `source`: the source module to use to initialise; required if `path` is 
-  specified
+* `from-module`: the source module to use to initialise; required if `path` is specified
 * `path`: the path to initialise.
 * `backend`: `true`/`false`, whether or not to configure the backend.
 * `get`: `true`/`false`, whether or not to get dependency modules.

--- a/lib/ruby_terraform/commands/apply.rb
+++ b/lib/ruby_terraform/commands/apply.rb
@@ -1,9 +1,14 @@
 require 'lino'
+require 'stringio'
 require_relative 'base'
 
 module RubyTerraform
   module Commands
     class Apply < Base
+      def stdout
+        @stdout ||= StringIO.new
+      end
+
       def configure_command(builder, opts)
         directory = opts[:directory]
         vars = opts[:vars] || {}
@@ -33,6 +38,24 @@ module RubyTerraform
               sub
             end
             .with_argument(directory)
+      end
+
+      def do_after(opts)
+        parse_apply_output(stdout.string)
+      end
+
+      private
+      def parse_apply_output(apply_output)
+        output_header = "Outputs:"
+        bash_colour_indicator = "\e"
+
+        return '' unless apply_output.include? output_header
+
+        apply_output.split(output_header)
+            .last
+            .split(bash_colour_indicator)
+            .first
+            .strip
       end
     end
   end


### PR DESCRIPTION
This PR contains two small changes.
- Make the "apply" command return the output as a string (as it does with "terraform apply") in the same format as "terraform output". I tried to follow the implementation pattern used in the "output" command
- Updated the README around the init command, where the "source" parameter got changed to "from-module" in the code