### PR TITLE
Add workspaces support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Currently, there is partial support for the following commands:
 * `RubyTerraform::Commands::Destroy`: executes `terraform destroy`
 * `RubyTerraform::Commands::Output`: executes `terraform output`
 * `RubyTerraform::Commands::RemoteConfig`: executes `terraform remote config`
+* `RubyTerraform::Commands::Workspace`: executes `terraform workspace`
 
 ### RubyTerraform::Commands::Clean
 
@@ -264,6 +265,23 @@ arguments:
 * `no_color`: whether or not the output from the command should be in color;
   defaults to `false`.
 
+### RubyTerraform::Commands::Workspace
+
+The `workspace` command configures [Terraform Workspaces](https://www.terraform.io/docs/state/workspaces.html#using-workspaces). It can be used as follows:
+
+```ruby
+RubyTerraform.workspace(operation: 'list') # terraform workspace list
+RubyTerraform.workspace(operation: 'new', workspace: 'staging') # terraform workspace new staging
+RubyTerraform.workspace(operation: 'select', workspace: 'staging') # terraform workspace select staging
+RubyTerraform.workspace(operation: 'list') # terraform workspace list
+RubyTerraform.workspace(operation: 'select', workspace: 'default') # terraform workspace select default
+RubyTerraform.workspace(operation: 'delete', workspace: 'staging') # terraform workspace delete staging
+```
+
+The workspace command supports the following options passed as keyword arguments:
+* `directory`: the directory containing terraform configuration, the default is the current path.
+* `operation`: `list`, `select`, `new` or `delete`. default `list`.
+* `workspace`: Workspace name.
 
 ## Development
 

--- a/lib/ruby_terraform.rb
+++ b/lib/ruby_terraform.rb
@@ -59,6 +59,10 @@ module RubyTerraform
       Commands::Output.new.execute(opts)
     end
 
+    def workspace(opts = {})
+      Commands::Workspace.new.execute(opts)
+    end
+
     def output_from_remote(opts)
       output_name = opts[:name]
       remote_opts = opts[:remote]

--- a/lib/ruby_terraform/commands.rb
+++ b/lib/ruby_terraform/commands.rb
@@ -9,6 +9,7 @@ require_relative 'commands/output'
 require_relative 'commands/refresh'
 require_relative 'commands/remote_config'
 require_relative 'commands/show'
+require_relative 'commands/workspace'
 
 module RubyTerraform
   module Commands

--- a/lib/ruby_terraform/commands/workspace.rb
+++ b/lib/ruby_terraform/commands/workspace.rb
@@ -1,0 +1,21 @@
+require 'lino'
+require_relative 'base'
+
+module RubyTerraform
+  module Commands
+    class Workspace < Base
+      def configure_command(builder, opts)
+        directory = opts[:directory] || nil
+        operation = opts[:operation] || 'list'
+        workspace = opts[:workspace] || nil
+
+        builder = builder
+            .with_subcommand('workspace')
+            .with_subcommand(operation)
+
+        builder = builder.with_subcommand(workspace) if workspace && operation != 'list'
+        builder = builder.with_argument(directory)
+      end
+    end
+  end
+end

--- a/spec/ruby_terraform/commands/workspace_spec.rb
+++ b/spec/ruby_terraform/commands/workspace_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+describe RubyTerraform::Commands::Workspace do
+  before(:each) do
+    RubyTerraform.configure do |config|
+      config.binary = 'path/to/binary'
+    end
+  end
+
+  after(:each) do
+    RubyTerraform.reset!
+  end
+
+  it 'calls the terraform workspace command passing the supplied directory' do
+    command = RubyTerraform::Commands::Workspace.new(binary: 'terraform')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with('terraform workspace list some/path/to/terraform/configuration', any_args))
+
+    command.execute(directory: 'some/path/to/terraform/configuration')
+  end
+
+  it 'defaults to the configured binary when none provided' do
+    command = RubyTerraform::Commands::Workspace.new
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with('path/to/binary workspace list some/path/to/terraform/configuration', any_args))
+
+    command.execute(directory: 'some/path/to/terraform/configuration')
+  end
+
+  it 'should defaults to list operation when no operation provided' do
+    command = RubyTerraform::Commands::Workspace.new
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with('path/to/binary workspace list', any_args))
+
+    command.execute
+  end
+
+  it 'should not use workspace option if operation list is provided' do
+    command = RubyTerraform::Commands::Workspace.new
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with('path/to/binary workspace list', any_args))
+
+    command.execute(operation: 'list', workspace: 'qa')
+  end
+
+  it 'should select the specified workspace' do
+    command = RubyTerraform::Commands::Workspace.new
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with('path/to/binary workspace select staging', any_args))
+
+    command.execute(operation: 'select', workspace: 'staging')
+  end
+
+  it 'should create the specified workspace' do
+    command = RubyTerraform::Commands::Workspace.new
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with('path/to/binary workspace new staging', any_args))
+
+    command.execute(operation: 'new', workspace: 'staging')
+  end
+
+  it 'should delete the specified workspace' do
+    command = RubyTerraform::Commands::Workspace.new
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with('path/to/binary workspace delete staging', any_args))
+
+    command.execute(operation: 'delete', workspace: 'staging')
+  end
+end


### PR DESCRIPTION
Hi there!

With this PR I'm adding suppport to `list`, create(`new`), `select` and `delete` [Terraform Workspaces](https://www.terraform.io/docs/state/workspaces.html#using-workspaces):

Examples: 
- `terraform workspace list`
```ruby
RubyTerraform.workspace(operation: 'list')
```
- `terraform workspace new staging`
```ruby
RubyTerraform.workspace(operation: 'new', workspace: 'staging')
```
- `terraform workspace delete staging`
```ruby
RubyTerraform.workspace(operation: 'delete', workspace: 'staging')
```