### PR TITLE
iMake clean command safer

### DIFF
--- a/lib/ruby_terraform/commands/clean.rb
+++ b/lib/ruby_terraform/commands/clean.rb
@@ -8,7 +8,7 @@ module RubyTerraform
       end
 
       def execute(opts = {})
-        FileUtils.rm_rf(opts[:directory] || @directory)
+        FileUtils.rm_r(opts[:directory] || @directory, :secure => true)
       end
     end
   end

--- a/spec/ruby_terraform/commands/clean_spec.rb
+++ b/spec/ruby_terraform/commands/clean_spec.rb
@@ -5,7 +5,7 @@ describe RubyTerraform::Commands::Clean do
     command = RubyTerraform::Commands::Clean.new
 
     expect(FileUtils).to(
-        receive(:rm_rf).with('.terraform'))
+        receive(:rm_r).with('.terraform', :secure => true))
 
     command.execute
   end
@@ -14,7 +14,7 @@ describe RubyTerraform::Commands::Clean do
     command = RubyTerraform::Commands::Clean.new(directory: 'some/path')
 
     expect(FileUtils).to(
-        receive(:rm_rf).with('some/path'))
+        receive(:rm_r).with('some/path', :secure => true))
 
     command.execute
   end
@@ -23,7 +23,7 @@ describe RubyTerraform::Commands::Clean do
     command = RubyTerraform::Commands::Clean.new
 
     expect(FileUtils).to(
-        receive(:rm_rf).with('some/.terraform'))
+        receive(:rm_r).with('some/.terraform', :secure => true))
 
     command.execute(directory: 'some/.terraform')
   end


### PR DESCRIPTION
The method `Clean` calls `FileUtils.rm_rf` which 

- causes local vulnerability 
- ignores StandardError

Thus, the change to `rm_r` (same goal of removing a path recursively) with `secure` option, as the [documentation points](https://github.com/JuanitoFatas/ruby-2.2.2-standard-library/blob/e5e1cc2b8cdb9e53e3a70f48e4e2d9c85d460c26/fileutils.rb#L632) to avoid this security hole.