### PR TITLE
Add support for import command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Currently, there is partial support for the following commands:
 * `RubyTerraform::Commands::Destroy`: executes `terraform destroy`
 * `RubyTerraform::Commands::Output`: executes `terraform output`
 * `RubyTerraform::Commands::Refresh`: executes `terraform refresh`
+* `RubyTerraform::Commands::Import`: executes `terraform import`
 * `RubyTerraform::Commands::RemoteConfig`: executes `terraform remote config`
 * `RubyTerraform::Commands::Validate`: executes `terraform validate`
 * `RubyTerraform::Commands::Workspace`: executes `terraform workspace`
@@ -241,6 +242,11 @@ The destroy command supports the following options passed as keyword arguments:
   `var_files` are provided, all var files will be passed to terraform.
 * `var_files`: an array of paths to terraform var files; if both `var_file` and
   `var_files` are provided, all var files will be passed to terraform.
+  * `module_depth`: the depth of modules to show in the output; defaults to
+  showing all modules.
+* `json`: whether or not the output from the command should be in json format;
+  defaults to `false`.
+
 * `target`: the address of a resource to target; if both `target` and
   `targets` are provided, all targets will be passed to terraform.
 * `targets`: and array of resource addresses to target; if both `target` and
@@ -307,6 +313,49 @@ The refresh command supports the following options passed as keyword arguments:
   terraform.tfstate in the working directory or the remote state if configured.
 * `input`: when `false`, will not ask for input for variables not directly set;
   defaults to `true`.
+* `no_color`: whether or not the output from the command should be in color;
+  defaults to `false`.
+
+
+### RubyTerraform::Commands::Import
+
+The import command imports existing infrastructure into your terraform state.
+It can be called in the following ways:
+
+```ruby
+RubyTerraform.import(
+  directory: 'infra/networking',
+  address: 'a.resource.address',
+  id: 'a-resource-id',
+  vars: {
+    region: 'eu-central'
+  }))
+RubyTerraform::Commands::Import.new.execute(
+  directory: 'infra/networking',
+  address: 'a.resource.address',
+  id: 'a-resource-id',
+  vars: {
+    region: 'eu-central'
+  }))
+```
+
+The import command supports the following options passed as keyword arguments:
+* `directory`: the directory containing terraform configuration; required.
+* `address`: a valid resource address; required.
+* `id`: id of resource being imported; required.
+* `vars`: a map of vars to be passed in to the terraform configuration.
+* `var_file`: the path to a terraform var file; if both `var_file` and
+  `var_files` are provided, all var files will be passed to terraform.
+* `var_files`: an array of paths to terraform var files; if both `var_file` and
+  `var_files` are provided, all var files will be passed to terraform.
+* `input`: when `false`, will not ask for input for variables not directly set;
+  defaults to `true`.
+* `state`: the path to the state file containing the current state; defaults to
+  terraform.tfstate in the working directory or the remote state if configured.
+* `module_depth`: the depth of modules to show in the output; defaults to
+  showing all modules.
+* `no_backup`: when `true`, no backup file will be written; defaults to `false`.
+* `backup`: the path to the backup file in which to store the state backup.
 * `no_color`: whether or not the output from the command should be in color;
   defaults to `false`.
 

--- a/README.md
+++ b/README.md
@@ -242,11 +242,6 @@ The destroy command supports the following options passed as keyword arguments:
   `var_files` are provided, all var files will be passed to terraform.
 * `var_files`: an array of paths to terraform var files; if both `var_file` and
   `var_files` are provided, all var files will be passed to terraform.
-  * `module_depth`: the depth of modules to show in the output; defaults to
-  showing all modules.
-* `json`: whether or not the output from the command should be in json format;
-  defaults to `false`.
-
 * `target`: the address of a resource to target; if both `target` and
   `targets` are provided, all targets will be passed to terraform.
 * `targets`: and array of resource addresses to target; if both `target` and

--- a/README.md
+++ b/README.md
@@ -352,8 +352,6 @@ The import command supports the following options passed as keyword arguments:
   defaults to `true`.
 * `state`: the path to the state file containing the current state; defaults to
   terraform.tfstate in the working directory or the remote state if configured.
-* `module_depth`: the depth of modules to show in the output; defaults to
-  showing all modules.
 * `no_backup`: when `true`, no backup file will be written; defaults to `false`.
 * `backup`: the path to the backup file in which to store the state backup.
 * `no_color`: whether or not the output from the command should be in color;

--- a/lib/ruby_terraform.rb
+++ b/lib/ruby_terraform.rb
@@ -68,6 +68,10 @@ module RubyTerraform
     def workspace(opts = {})
       Commands::Workspace.new.execute(opts)
     end
+
+    def import(opts = {})
+      Commands::Import.new.execute(opts)
+    end
   end
   extend ClassMethods
 

--- a/lib/ruby_terraform/commands.rb
+++ b/lib/ruby_terraform/commands.rb
@@ -10,6 +10,7 @@ require_relative 'commands/refresh'
 require_relative 'commands/remote_config'
 require_relative 'commands/show'
 require_relative 'commands/workspace'
+require_relative 'commands/import'
 
 module RubyTerraform
   module Commands

--- a/lib/ruby_terraform/commands/import.rb
+++ b/lib/ruby_terraform/commands/import.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'lino'
+require_relative 'base'
+
+module RubyTerraform
+  module Commands
+    class Import < Base
+      def configure_command(builder, opts)
+        directory = opts[:directory]
+        vars = opts[:vars] || {}
+        var_file = opts[:var_file]
+        var_files = opts[:var_files] || []
+        no_color = opts[:no_color]
+        no_backup = opts[:no_backup]
+        backup = no_backup ? '-' : opts[:backup]
+        state = opts[:state]
+        input = opts[:input]
+        address = opts[:address]
+        id = opts[:id]
+
+        builder
+          .with_subcommand('import') do |sub|
+            sub = sub.with_option('-config', directory)
+            vars.each do |key, value|
+              var_value = value.is_a?(String) ? value : JSON.generate(value)
+              sub = sub.with_option(
+                '-var', "'#{key}=#{var_value}'", separator: ' '
+              )
+            end
+            sub = sub.with_option('-var-file', var_file) if var_file
+            var_files.each do |file|
+              sub = sub.with_option('-var-file', file)
+            end
+            sub = sub.with_option('-state', state) if state
+            sub = sub.with_option('-input', input) if input
+            sub = sub.with_option('-backup', backup) if backup
+            sub = sub.with_flag('-no-color') if no_color
+            sub
+          end
+          .with_argument(address)
+          .with_argument(id)
+      end
+    end
+  end
+end

--- a/spec/ruby_terraform/commands/import_spec.rb
+++ b/spec/ruby_terraform/commands/import_spec.rb
@@ -1,0 +1,260 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe RubyTerraform::Commands::Import do
+  before(:each) do
+    RubyTerraform.configure do |config|
+      config.binary = 'path/to/binary'
+    end
+  end
+
+  after(:each) do
+    RubyTerraform.reset!
+  end
+
+  it 'calls the terraform import command passing the supplied directory' do
+    command = RubyTerraform::Commands::Import.new(binary: 'terraform')
+
+    expect(Open4).to(
+      receive(:spawn)
+        .with('terraform import -config=some/path/to/terraform/configuration a.resource.address a-resource-id', any_args)
+    )
+
+    command.execute(
+      directory: 'some/path/to/terraform/configuration',
+      address: 'a.resource.address',
+      id: 'a-resource-id'
+    )
+  end
+
+  it 'defaults to the configured binary when none provided' do
+    command = RubyTerraform::Commands::Import.new
+
+    expect(Open4).to(
+      receive(:spawn)
+          .with('path/to/binary import -config=some/path/to/terraform/configuration a.resource.address-2 a-resource-id.3', any_args)
+    )
+
+    command.execute(
+      directory: 'some/path/to/terraform/configuration',
+      address: 'a.resource.address-2',
+      id: 'a-resource-id.3'
+    )
+  end
+
+  it 'adds a var option for each supplied var' do
+    command = RubyTerraform::Commands::Import.new(binary: 'terraform')
+
+    expect(Open4).to(
+      receive(:spawn)
+        .with("terraform import -config=some/configuration -var 'first=1' -var 'second=two' a.resource.address a-resource-id", any_args)
+    )
+
+    command.execute(
+      directory: 'some/configuration',
+      address: 'a.resource.address',
+      id: 'a-resource-id',
+      vars: {
+        first: 1,
+        second: 'two'
+      }
+    )
+  end
+
+  it 'correctly serialises list/tuple vars' do
+    command = RubyTerraform::Commands::Import.new(binary: 'terraform')
+
+    expect(Open4).to(
+      receive(:spawn)
+          .with("terraform import -config=some/configuration -var 'list=[1,\"two\",3]' a.resource.address a-resource-id", any_args)
+    )
+
+    command.execute(
+      directory: 'some/configuration',
+      address: 'a.resource.address',
+      id: 'a-resource-id',
+      vars: {
+        list: [1, 'two', 3]
+      }
+    )
+  end
+
+  it 'correctly serialises map/object vars' do
+    command = RubyTerraform::Commands::Import.new(binary: 'terraform')
+
+    expect(Open4).to(
+      receive(:spawn)
+          .with("terraform import -config=some/configuration -var 'map={\"first\":1,\"second\":\"two\"}' a.resource.address a-resource-id", any_args)
+    )
+
+    command.execute(
+      directory: 'some/configuration',
+      address: 'a.resource.address',
+      id: 'a-resource-id',
+      vars: {
+        map: {
+          first: 1,
+          second: 'two'
+        }
+      }
+    )
+  end
+
+  it 'correctly serialises vars with lists/tuples of maps/objects' do
+    command = RubyTerraform::Commands::Import.new(binary: 'terraform')
+
+    expect(Open4).to(
+      receive(:spawn)
+          .with("terraform import -config=some/configuration -var 'list_of_maps=[{\"key\":\"value\"},{\"key\":\"value\"}]' a.resource.address a-resource-id", any_args)
+    )
+
+    command.execute(
+      directory: 'some/configuration',
+      address: 'a.resource.address',
+      id: 'a-resource-id',
+      vars: {
+        list_of_maps: [
+          { key: 'value' },
+          { key: 'value' }
+        ]
+      }
+    )
+  end
+
+  it 'adds a state option if a state path is provided' do
+    command = RubyTerraform::Commands::Import.new(binary: 'terraform')
+
+    expect(Open4).to(
+      receive(:spawn)
+          .with('terraform import -config=some/configuration -state=some/state.tfstate a.resource.address a-resource-id', any_args)
+    )
+
+    command.execute(
+      directory: 'some/configuration',
+      address: 'a.resource.address',
+      id: 'a-resource-id',
+      state: 'some/state.tfstate'
+    )
+  end
+
+  it 'adds a backup option if a backup path is provided' do
+    command = RubyTerraform::Commands::Import.new(binary: 'terraform')
+
+    expect(Open4).to(
+      receive(:spawn)
+          .with('terraform import -config=some/configuration -backup=some/state.tfstate.backup a.resource.address a-resource-id', any_args)
+    )
+
+    command.execute(
+      directory: 'some/configuration',
+      address: 'a.resource.address',
+      id: 'a-resource-id',
+      backup: 'some/state.tfstate.backup'
+    )
+  end
+
+  it 'disables backup if no_backup is true' do
+    command = RubyTerraform::Commands::Import.new(binary: 'terraform')
+
+    expect(Open4).to(
+      receive(:spawn)
+          .with('terraform import -config=some/configuration -backup=- a.resource.address a-resource-id', any_args)
+    )
+
+    command.execute(
+      directory: 'some/configuration',
+      address: 'a.resource.address',
+      id: 'a-resource-id',
+      backup: 'some/state.tfstate.backup',
+      no_backup: true
+    )
+  end
+
+  it 'includes the no-color flag when the no_color option is true' do
+    command = RubyTerraform::Commands::Import.new(binary: 'terraform')
+
+    expect(Open4).to(
+      receive(:spawn)
+          .with('terraform import -config=some/path/to/terraform/configuration -no-color a.resource.address a-resource-id', any_args)
+    )
+
+    command.execute(
+      directory: 'some/path/to/terraform/configuration',
+      address: 'a.resource.address',
+      id: 'a-resource-id',
+      no_color: true
+    )
+  end
+
+  it 'adds a var-file option if a var file is provided' do
+    command = RubyTerraform::Commands::Import.new(binary: 'terraform')
+
+    expect(Open4).to(
+      receive(:spawn)
+          .with('terraform import -config=some/configuration -var-file=some/vars.tfvars a.resource.address a-resource-id', any_args)
+    )
+
+    command.execute(
+      directory: 'some/configuration',
+      address: 'a.resource.address',
+      id: 'a-resource-id',
+      var_file: 'some/vars.tfvars'
+    )
+  end
+
+  it 'adds a var-file option for each element of var-files array' do
+    command = RubyTerraform::Commands::Import.new(binary: 'terraform')
+
+    expect(Open4).to(
+      receive(:spawn)
+          .with('terraform import -config=some/configuration -var-file=some/vars1.tfvars -var-file=some/vars2.tfvars a.resource.address a-resource-id', any_args)
+    )
+
+    command.execute(
+      directory: 'some/configuration',
+      address: 'a.resource.address',
+      id: 'a-resource-id',
+      var_files: [
+        'some/vars1.tfvars',
+        'some/vars2.tfvars'
+      ]
+    )
+  end
+
+  it 'ensures that var_file and var_files options work together' do
+    command = RubyTerraform::Commands::Import.new(binary: 'terraform')
+
+    expect(Open4).to(
+      receive(:spawn)
+          .with('terraform import -config=some/configuration -var-file=some/vars.tfvars -var-file=some/vars1.tfvars -var-file=some/vars2.tfvars a.resource.address a-resource-id', any_args)
+    )
+
+    command.execute(
+      directory: 'some/configuration',
+      address: 'a.resource.address',
+      id: 'a-resource-id',
+      var_file: 'some/vars.tfvars',
+      var_files: [
+        'some/vars1.tfvars',
+        'some/vars2.tfvars'
+      ]
+    )
+  end
+
+  it 'adds a input option if a input value is provided' do
+    command = RubyTerraform::Commands::Import.new(binary: 'terraform')
+
+    expect(Open4).to(
+      receive(:spawn)
+          .with('terraform import -config=some/configuration -input=false a.resource.address a-resource-id', any_args)
+    )
+
+    command.execute(
+      directory: 'some/configuration',
+      address: 'a.resource.address',
+      id: 'a-resource-id',
+      input: 'false'
+    )
+  end
+end


### PR DESCRIPTION
Adding support for the `terraform import` command.

Closes #42 