### PR TITLE
Enable a require that matches Gem name's hyphen

### DIFF
--- a/lib/ruby-terraform.rb
+++ b/lib/ruby-terraform.rb
@@ -1,0 +1,3 @@
+# Enable `require 'ruby-terraform'`, to match the gem name
+
+require_relative 'ruby_terraform.rb'


### PR DESCRIPTION
This PR enables the RubyTerraform gem to be `require`d by its gem name, which uses a hyphen, `ruby-terraform`.  Currently, the library can only be required by its underscored name, `ruby_terraform`, which does not match its gem name.

When using RubyTerraform in a Ruby on Rails app, I found the library was not being auto-loaded, despite being in the Gemfile.  Unless the app explicitly included a `require "ruby_terraform"`, it would throw the exception `uninitialized constant RubyTerraform (NameError)`.  After chasing this through several rabbit holes, I realized that Rails' invocation of Bundler expects the convention that a gem can be `require`d by its gem name.

The issue can be illustrated by this excerpt from a Rails console:

```ruby
[1] pry(main)> Bundler.require(*Rails.groups)
=> [Gem::Dependency.new("aws-sdk-ec2", Gem::Requirement.new(["~> 1"]), :runtime),
---&<---
 Gem::Dependency.new("ruby-terraform", Gem::Requirement.new(["~> 0.56.0"]), :runtime)]

[2] pry(main)> RubyTerraform
NameError: uninitialized constant RubyTerraform

[3] pry(main)> require 'ruby-terraform'
LoadError: cannot load such file -- ruby-terraform

[4] pry(main)> require 'ruby_terraform'
=> true
[5] pry(main)> 
```

This PR is a small patch to make both names work, with the hyphen and underscore.  This allows Rails to auto-load the gem, with its hyphen, while not breaking backward compatibility with code that requires the gem using the underscore name.

Incidentally, Rubygems does have another gem called [`ruby_terraform`](https://rubygems.org/gems/ruby_terraform), with the underscore.  It appears that one is from 2016, with no further updates, and pre-dates the earliest version of this gem.