### PR TITLE
RFC - DRY Command Building

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,11 @@
+AllCops:
+  NewCops: enable
+
+Metrics/BlockLength:
+  IgnoredMethods:
+    - describe
+    - context
+    - shared_examples
+
+Style/Documentation:
+  Enabled: false

--- a/lib/ruby_terraform/command_line/boolean_option.rb
+++ b/lib/ruby_terraform/command_line/boolean_option.rb
@@ -1,0 +1,18 @@
+require_relative 'boolean_value_functionality'
+require_relative 'option'
+
+module RubyTerraform
+  module CommandLine
+    class BooleanOption < Option
+      include BooleanValueFunctionality
+
+      def add_option_to_subcommand(sub)
+        if value.nil?
+          sub
+        else
+          sub.with_option(switch, value)
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_terraform/command_line/boolean_value_functionality.rb
+++ b/lib/ruby_terraform/command_line/boolean_value_functionality.rb
@@ -1,0 +1,17 @@
+module RubyTerraform
+  module CommandLine
+    module BooleanValueFunctionality
+      def assign_option_value(value)
+        @value = boolean_val(value)
+      end
+
+      def boolean_val(variable)
+        return nil if variable.nil?
+        return variable if variable.is_a?(TrueClass) || variable.is_a?(FalseClass)
+        return true if variable.respond_to?(:upcase) && variable[0].upcase == 'T'
+
+        false
+      end
+    end
+  end
+end

--- a/lib/ruby_terraform/command_line/builder.rb
+++ b/lib/ruby_terraform/command_line/builder.rb
@@ -1,0 +1,55 @@
+require 'lino'
+
+module RubyTerraform
+  module CommandLine
+    class Builder
+      def initialize(binary:, command_line_commands:, command_line_options:, command_line_arguments:)
+        @builder = instantiate_builder(binary)
+        @command_line_commands = array_of(command_line_commands)
+        @command_line_options = command_line_options
+        @command_line_arguments = array_of(command_line_arguments)
+      end
+
+      def build
+        configure_builder
+        builder.build
+      end
+
+      private
+
+      attr_reader :builder, :command_line_commands, :command_line_options, :command_line_arguments
+
+      def configure_builder
+        add_subcommands_and_options
+        add_arguments
+      end
+
+      def add_subcommands_and_options
+        command_line_commands[0...-1].each { |command| @builder = builder.with_subcommand(command) }
+        @builder = builder.with_subcommand(command_line_commands[-1]) do |sub|
+          command_line_options.inject(sub) do |sub, command_line_option|
+            command_line_option.add_to_subcommand(sub)
+          end
+        end
+      end
+
+      def add_arguments
+        command_line_arguments.each do |argument|
+          @builder = builder.with_argument(argument) if argument
+        end
+      end
+
+      def instantiate_builder(binary)
+        Lino::CommandLineBuilder
+          .for_command(binary)
+          .with_option_separator('=')
+      end
+
+      def array_of(value)
+        return value if value.respond_to?(:each)
+
+        [value]
+      end
+    end
+  end
+end

--- a/lib/ruby_terraform/command_line/flag.rb
+++ b/lib/ruby_terraform/command_line/flag.rb
@@ -1,0 +1,18 @@
+require_relative 'boolean_value_functionality'
+require_relative 'option'
+
+module RubyTerraform
+  module CommandLine
+    class Flag < Option
+      include BooleanValueFunctionality
+
+      def add_option_to_subcommand(sub)
+        if value.nil? || !value
+          sub
+        else
+          sub.with_flag(switch)
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_terraform/command_line/option.rb
+++ b/lib/ruby_terraform/command_line/option.rb
@@ -1,0 +1,60 @@
+require 'json'
+
+module RubyTerraform
+  module CommandLine
+    class Option
+      def initialize(opt_key, value, switch_override: nil)
+        assign_option_value(value)
+        @switch = switch_override || switch_from_key(opt_key)
+      end
+
+      def add_to_subcommand(sub)
+        if value.respond_to?(:keys)
+          add_hash_to_subcommand(sub, value)
+        elsif value.respond_to?(:each)
+          add_array_to_subcommand(sub, value)
+        else
+          add_option_to_subcommand(sub)
+        end || sub
+      end
+
+      private
+
+      attr_reader :switch, :value
+
+      def assign_option_value(value)
+        @value = value
+      end
+
+      def switch_from_key(opt_key)
+        "-#{opt_key.to_s.sub('_', '-')}"
+      end
+
+      def add_hash_to_subcommand(sub, hash)
+        hash.each do |hash_key, hash_value|
+          sub = sub.with_option(switch, "'#{hash_key}=#{as_string(hash_value)}'", separator: ' ')
+        end
+        sub
+      end
+
+      def add_array_to_subcommand(sub, array)
+        array.each do |element|
+          sub = sub.with_option(switch, element)
+        end
+        sub
+      end
+
+      def add_option_to_subcommand(sub)
+        if value
+          sub.with_option(switch, value)
+        else
+          sub
+        end
+      end
+
+      def as_string(value)
+        value.is_a?(String) ? value : JSON.generate(value)
+      end
+    end
+  end
+end

--- a/lib/ruby_terraform/command_line/options.rb
+++ b/lib/ruby_terraform/command_line/options.rb
@@ -1,0 +1,44 @@
+require_relative 'option'
+require_relative 'flag'
+require_relative 'boolean_option'
+
+module RubyTerraform
+  module CommandLine
+    class Options < Array
+      def initialize(option_values:, command_arguments:)
+        super()
+        @option_values = option_values
+        append_options_with_switch_overrides(command_arguments[:switch_overrides])
+        append_options(command_arguments[:standard])
+        append_boolean_options(command_arguments[:boolean])
+        append_flags(command_arguments[:flags])
+      end
+
+      private
+
+      attr_reader :option_values
+
+      def append_options(options)
+        (options || []).each { |opt_key| append(command_line_option(opt_key)) }
+      end
+
+      def append_options_with_switch_overrides(options)
+        (options || {}).each do |opt_key, switch_override|
+          append(command_line_option(opt_key, switch_override))
+        end
+      end
+
+      def append_boolean_options(options)
+        (options || []).each { |opt_key| append(BooleanOption.new(opt_key, option_values[opt_key])) }
+      end
+
+      def append_flags(options)
+        (options || []).each { |opt_key| append(Flag.new(opt_key, option_values[opt_key])) }
+      end
+
+      def command_line_option(opt_key, switch_override = nil)
+        Option.new(opt_key, option_values[opt_key], switch_override: switch_override)
+      end
+    end
+  end
+end

--- a/lib/ruby_terraform/command_line/options.rb
+++ b/lib/ruby_terraform/command_line/options.rb
@@ -14,11 +14,16 @@ module RubyTerraform
         append_flags(command_arguments[:flags])
       end
 
+      def self.global_options
+        %i[chdir]
+      end
+
       private
 
       attr_reader :option_values
 
       def append_options(options)
+        Options.global_options.each { |opt_key| append(command_line_option(opt_key)) }
         (options || []).each { |opt_key| append(command_line_option(opt_key)) }
       end
 

--- a/lib/ruby_terraform/commands/apply.rb
+++ b/lib/ruby_terraform/commands/apply.rb
@@ -8,9 +8,9 @@ module RubyTerraform
         RubyTerraform::CommandLine::Options.new(
           option_values: option_values,
           command_arguments: {
-            standard: %i[backup state target var_file],
-            boolean: %i[auto_approve input],
-            flags: %i[no_color],
+            standard: %i[backup lock_timeout parallelism state state_out target var var_file],
+            boolean: %i[auto_approve input lock refresh],
+            flags: %i[compact_warnings no_color],
             switch_overrides: { vars: '-var', targets: '-target', var_files: '-var-file' }
           }
         )

--- a/lib/ruby_terraform/commands/base.rb
+++ b/lib/ruby_terraform/commands/base.rb
@@ -1,29 +1,27 @@
-require 'lino'
 require_relative '../errors'
+require_relative '../command_line/builder'
+require_relative '../command_line/options'
 
 module RubyTerraform
   module Commands
     class Base
-      def initialize(
-          binary: nil, logger: nil, stdin: nil, stdout: nil, stderr: nil)
+      def initialize(binary: nil, logger: nil, stdin: nil, stdout: nil, stderr: nil)
         @binary = binary || RubyTerraform.configuration.binary
         @logger = logger || RubyTerraform.configuration.logger
         @stdin = stdin || RubyTerraform.configuration.stdin
         @stdout = stdout || RubyTerraform.configuration.stdout
         @stderr = stderr || RubyTerraform.configuration.stderr
+        initialize_command
       end
 
       def execute(opts = {})
-        builder = instantiate_builder
-
         do_before(opts)
-        command = configure_command(builder, opts).build
-        logger.debug("Running '#{command.to_s}'.")
-
+        command = build_command(opts)
+        logger.debug("Running '#{command}'.")
         command.execute(
-            stdin: stdin,
-            stdout: stdout,
-            stderr: stderr
+          stdin: stdin,
+          stdout: stdout,
+          stderr: stderr
         )
         do_after(opts)
       rescue Open4::SpawnError
@@ -37,22 +35,52 @@ module RubyTerraform
       attr_reader :binary, :logger, :stdin, :stdout, :stderr
 
       def command_name
-        self.class.to_s.split("::")[-1].downcase
+        self.class.to_s.split('::')[-1].downcase
       end
 
-      def instantiate_builder
-        Lino::CommandLineBuilder
-            .for_command(binary)
-            .with_option_separator('=')
+      def do_before(_opts); end
+
+      def do_after(_opts); end
+
+      private
+
+      def initialize_command; end
+
+      def build_command(opts)
+        option_values = apply_option_defaults_and_overrides(opts)
+        RubyTerraform::CommandLine::Builder.new(
+          binary: @binary,
+          command_line_commands: command_line_commands(option_values),
+          command_line_options: command_line_options(option_values),
+          command_line_arguments: command_line_arguments(option_values)
+        ).build
       end
 
-      def do_before(opts)
+      def apply_option_defaults_and_overrides(opts)
+        option_default_values(opts).merge(opts).merge(option_override_values(opts))
       end
 
-      def configure_command(builder, opts)
+      def option_default_values(_option_values)
+        {}
       end
 
-      def do_after(opts)
+      def option_override_values(_option_values)
+        {}
+      end
+
+      def command_line_commands(_option_values)
+        []
+      end
+
+      def command_line_options(_option_values)
+        RubyTerraform::CommandLine::Options.new(
+          option_values: _option_values,
+          command_arguments: {}
+        )
+      end
+
+      def command_line_arguments(_option_values)
+        []
       end
     end
   end

--- a/lib/ruby_terraform/commands/destroy.rb
+++ b/lib/ruby_terraform/commands/destroy.rb
@@ -1,46 +1,35 @@
 require_relative 'base'
+require_relative '../command_line/options'
 
 module RubyTerraform
   module Commands
     class Destroy < Base
-      def configure_command(builder, opts)
-        directory = opts[:directory]
-        vars = opts[:vars] || {}
-        var_file = opts[:var_file]
-        var_files = opts[:var_files] || []
-        target = opts[:target]
-        targets = opts[:targets] || []
-        state = opts[:state]
-        force = opts[:force]
-        no_backup = opts[:no_backup]
-        backup = no_backup ? '-' : opts[:backup]
-        no_color = opts[:no_color]
-        auto_approve = opts[:auto_approve]
+      def command_line_options(option_values)
+        RubyTerraform::CommandLine::Options.new(
+          option_values: option_values,
+          command_arguments: {
+            standard: %i[backup state target var_file],
+            boolean: %i[auto_approve],
+            flags: %i[force no_color],
+            switch_overrides: { vars: '-var', targets: '-target', var_files: '-var-file' }
+          }
+        )
+      end
 
-        builder
-            .with_subcommand('destroy') do |sub|
-              vars.each do |key, value|
-                var_value = value.is_a?(String) ? value : JSON.generate(value)
-                sub = sub.with_option(
-                    '-var', "'#{key}=#{var_value}'", separator: ' ')
-              end
-              sub = sub.with_option('-var-file', var_file) if var_file
-              var_files.each do |file|
-                sub = sub.with_option('-var-file', file)
-              end
-              sub = sub.with_option('-target', target) if target
-              targets.each do |target_name|
-                sub = sub.with_option('-target', target_name)
-              end
-              sub = sub.with_option('-state', state) if state
-              sub = sub.with_option('-auto-approve', auto_approve) unless
-                  auto_approve.nil?
-              sub = sub.with_option('-backup', backup) if backup
-              sub = sub.with_flag('-no-color') if no_color
-              sub = sub.with_flag('-force') if force
-              sub
-            end
-            .with_argument(directory)
+      def command_line_commands(_option_values)
+        'destroy'
+      end
+
+      def command_line_arguments(option_values)
+        option_values[:directory]
+      end
+
+      def option_default_values(_opts)
+        { vars: {}, var_files: [], targets: [] }
+      end
+
+      def option_override_values(opts)
+        { backup: opts[:no_backup] ? '-' : opts[:backup] }
       end
     end
   end

--- a/lib/ruby_terraform/commands/destroy.rb
+++ b/lib/ruby_terraform/commands/destroy.rb
@@ -8,8 +8,8 @@ module RubyTerraform
         RubyTerraform::CommandLine::Options.new(
           option_values: option_values,
           command_arguments: {
-            standard: %i[backup state target var_file],
-            boolean: %i[auto_approve],
+            standard: %i[backup lock_timeout parallelism state state_out target var var_file],
+            boolean: %i[auto_approve lock refresh],
             flags: %i[force no_color],
             switch_overrides: { vars: '-var', targets: '-target', var_files: '-var-file' }
           }

--- a/lib/ruby_terraform/commands/format.rb
+++ b/lib/ruby_terraform/commands/format.rb
@@ -1,29 +1,27 @@
 # frozen_string_literal: true
 
 require_relative 'base'
+require_relative '../command_line/options'
 
 module RubyTerraform
   module Commands
     class Format < Base
-      def configure_command(builder, opts)
-        directory = opts[:directory]
-        check = opts[:check]
-        diff = opts[:diff]
-        list = opts[:list]
-        no_color = opts[:no_color]
-        recursive = opts[:recursive]
-        write = opts[:write]
+      def command_line_options(option_values)
+        RubyTerraform::CommandLine::Options.new(
+          option_values: option_values,
+          command_arguments: {
+            boolean: %i[list write],
+            flags: %i[check diff no_color recursive]
+          }
+        )
+      end
 
-        builder.with_subcommand('fmt') do |sub|
-          sub = sub.with_option('-list', list) if list
-          sub = sub.with_option('-write', write) if write
+      def command_line_commands(_option_values)
+        'fmt'
+      end
 
-          sub = sub.with_flag('-check') if check
-          sub = sub.with_flag('-diff') if diff
-          sub = sub.with_flag('-no-color') if no_color
-          sub = sub.with_flag('-recursive') if recursive
-          sub
-        end.with_argument(directory)
+      def command_line_arguments(option_values)
+        option_values[:directory]
       end
     end
   end

--- a/lib/ruby_terraform/commands/get.rb
+++ b/lib/ruby_terraform/commands/get.rb
@@ -1,16 +1,24 @@
 require_relative 'base'
+require_relative '../command_line/options'
 
 module RubyTerraform
   module Commands
     class Get < Base
-      def configure_command(builder, opts)
-        builder
-            .with_subcommand('get') do |sub|
-              sub = sub.with_option('-update', true) if opts[:update]
-              sub = sub.with_flag('-no-color') if opts[:no_color]
-              sub
-            end
-            .with_argument(opts[:directory])
+      def command_line_options(option_values)
+        RubyTerraform::CommandLine::Options.new(
+          option_values: option_values,
+          command_arguments: {
+            flags: %i[no_color update]
+          }
+        )
+      end
+
+      def command_line_commands(_option_values)
+        'get'
+      end
+
+      def command_line_arguments(option_values)
+        option_values[:directory]
       end
     end
   end

--- a/lib/ruby_terraform/commands/import.rb
+++ b/lib/ruby_terraform/commands/import.rb
@@ -1,45 +1,37 @@
 # frozen_string_literal: true
 
-require 'json'
 require_relative 'base'
+require_relative '../command_line/options'
 
 module RubyTerraform
   module Commands
-    class Import < Base
-      def configure_command(builder, opts)
-        directory = opts[:directory]
-        vars = opts[:vars] || {}
-        var_file = opts[:var_file]
-        var_files = opts[:var_files] || []
-        no_color = opts[:no_color]
-        no_backup = opts[:no_backup]
-        backup = no_backup ? '-' : opts[:backup]
-        state = opts[:state]
-        input = opts[:input]
-        address = opts[:address]
-        id = opts[:id]
+    class Import < Base#
+      def command_line_options(option_values)
+        RubyTerraform::CommandLine::Options.new(
+          option_values: option_values,
+          command_arguments: {
+            standard: %i[backup state var_file],
+            boolean: %i[input],
+            flags: %i[no_color],
+            switch_overrides: { directory: '-config', vars: '-var', var_files: '-var-file' }
+          }
+        )
+      end
 
-        builder
-          .with_subcommand('import') do |sub|
-            sub = sub.with_option('-config', directory)
-            vars.each do |key, value|
-              var_value = value.is_a?(String) ? value : JSON.generate(value)
-              sub = sub.with_option(
-                '-var', "'#{key}=#{var_value}'", separator: ' '
-              )
-            end
-            sub = sub.with_option('-var-file', var_file) if var_file
-            var_files.each do |file|
-              sub = sub.with_option('-var-file', file)
-            end
-            sub = sub.with_option('-state', state) if state
-            sub = sub.with_option('-input', input) if input
-            sub = sub.with_option('-backup', backup) if backup
-            sub = sub.with_flag('-no-color') if no_color
-            sub
-          end
-          .with_argument(address)
-          .with_argument(id)
+      def command_line_commands(_option_values)
+        'import'
+      end
+
+      def command_line_arguments(option_values)
+        [option_values[:address], option_values[:id]]
+      end
+
+      def option_default_values(_opts)
+        { vars: {}, var_files: [] }
+      end
+
+      def option_override_values(opts)
+        { backup: opts[:no_backup] ? '-' : opts[:backup] }
       end
     end
   end

--- a/lib/ruby_terraform/commands/import.rb
+++ b/lib/ruby_terraform/commands/import.rb
@@ -10,9 +10,9 @@ module RubyTerraform
         RubyTerraform::CommandLine::Options.new(
           option_values: option_values,
           command_arguments: {
-            standard: %i[backup state var_file],
-            boolean: %i[input],
-            flags: %i[no_color],
+            standard: %i[backup lock_timeout state state_out var var_file],
+            boolean: %i[input lock],
+            flags: %i[allow_missing_config ignore_remote_version no_color],
             switch_overrides: { directory: '-config', vars: '-var', var_files: '-var-file' }
           }
         )

--- a/lib/ruby_terraform/commands/init.rb
+++ b/lib/ruby_terraform/commands/init.rb
@@ -1,38 +1,30 @@
 require_relative 'base'
+require_relative '../command_line/options'
 
 module RubyTerraform
   module Commands
     class Init < Base
-      def configure_command(builder, opts)
-        no_color = opts[:no_color]
-        backend = opts[:backend]
-        get = opts[:get]
-        backend_config = opts[:backend_config] || {}
-        source = opts[:from_module]
-        path = opts[:path]
-        plugin_dir = opts[:plugin_dir]
-        force_copy = opts[:force_copy]
+      def command_line_options(option_values)
+        RubyTerraform::CommandLine::Options.new(
+          option_values: option_values,
+          command_arguments: {
+            standard: %i[backend_config from_module plugin_dir],
+            boolean: %i[backend force_copy get],
+            flags: %i[no_color]
+          }
+        )
+      end
 
-        builder = builder
-            .with_subcommand('init') do |sub|
-              sub = sub.with_option('-backend', backend) unless backend.nil?
-              sub = sub.with_option('-force-copy', force_copy) unless force_copy.nil?
-              sub = sub.with_option('-get', get) unless get.nil?
-              sub = sub.with_option('-from-module', source) if source
-              sub = sub.with_flag('-no-color') if no_color
-              sub = sub.with_option('-plugin-dir', plugin_dir) unless plugin_dir.nil?
-              backend_config.each do |key, value|
-                sub = sub.with_option(
-                    '-backend-config',
-                    "'#{key}=#{value}'",
-                    separator: ' ')
-              end
-              sub
-            end
+      def command_line_commands(_option_values)
+        'init'
+      end
 
-        builder = builder.with_argument(path) if path
+      def command_line_arguments(option_values)
+        option_values[:path]
+      end
 
-        builder
+      def option_default_values(_opts)
+        { backend_config: {} }
       end
     end
   end

--- a/lib/ruby_terraform/commands/init.rb
+++ b/lib/ruby_terraform/commands/init.rb
@@ -8,9 +8,9 @@ module RubyTerraform
         RubyTerraform::CommandLine::Options.new(
           option_values: option_values,
           command_arguments: {
-            standard: %i[backend_config from_module plugin_dir],
-            boolean: %i[backend force_copy get],
-            flags: %i[no_color]
+            standard: %i[backend_config from_module lock_timeout plugin_dir],
+            boolean: %i[backend force_copy get get_plugins input lock upgrade verify_plugins],
+            flags: %i[no_color reconfigure]
           }
         )
       end

--- a/lib/ruby_terraform/commands/output.rb
+++ b/lib/ruby_terraform/commands/output.rb
@@ -1,32 +1,30 @@
 require 'stringio'
 require_relative 'base'
+require_relative '../command_line/options'
 
 module RubyTerraform
   module Commands
     class Output < Base
-      def initialize(**kwargs)
-        super(**kwargs)
-        @stdout = StringIO.new unless
-            defined?(@stdout) && @stdout.respond_to?(:string)
+      def initialize_command
+        @stdout = StringIO.new unless defined?(@stdout) && @stdout.respond_to?(:string)
       end
 
-      def configure_command(builder, opts)
-        name = opts[:name]
-        state = opts[:state]
-        no_color = opts[:no_color]
-        json = opts[:json]
-        mod = opts[:module]
+      def command_line_options(option_values)
+        RubyTerraform::CommandLine::Options.new(
+          option_values: option_values,
+          command_arguments: {
+            standard: %i[module state],
+            flags: %i[json no_color]
+          }
+        )
+      end
 
-        builder = builder
-            .with_subcommand('output') do |sub|
-          sub = sub.with_flag('-no-color') if no_color
-          sub = sub.with_flag('-json') if json
-          sub = sub.with_option('-state', state) if state
-          sub = sub.with_option('-module', mod) if mod
-          sub
-        end
-        builder = builder.with_argument(name) if name
-        builder
+      def command_line_commands(_option_values)
+        'output'
+      end
+
+      def command_line_arguments(option_values)
+        option_values[:name]
       end
 
       def do_after(opts)

--- a/lib/ruby_terraform/commands/plan.rb
+++ b/lib/ruby_terraform/commands/plan.rb
@@ -1,45 +1,31 @@
-require 'json'
 require_relative 'base'
+require_relative '../command_line/options'
 
 module RubyTerraform
   module Commands
     class Plan < Base
-      def configure_command(builder, opts)
-        directory = opts[:directory]
-        vars = opts[:vars] || {}
-        var_file = opts[:var_file]
-        var_files = opts[:var_files] || []
-        target = opts[:target]
-        targets = opts[:targets] || []
-        state = opts[:state]
-        plan = opts[:plan]
-        input = opts[:input]
-        destroy = opts[:destroy]
-        no_color = opts[:no_color]
+      def command_line_options(option_values)
+        RubyTerraform::CommandLine::Options.new(
+          option_values: option_values,
+          command_arguments: {
+            standard: %i[state target var_file],
+            boolean: %i[input],
+            flags: %i[destroy no_color],
+            switch_overrides: { vars: '-var', targets: '-target', var_files: '-var-file', plan: '-out' }
+          }
+        )
+      end
 
-        builder
-            .with_subcommand('plan') do |sub|
-              vars.each do |key, value|
-                var_value = value.is_a?(String) ? value : JSON.generate(value)
-                sub = sub.with_option(
-                    '-var', "'#{key}=#{var_value}'", separator: ' ')
-              end
-              sub = sub.with_option('-var-file', var_file) if var_file
-              var_files.each do |file|
-                sub = sub.with_option('-var-file', file)
-              end
-              sub = sub.with_option('-target', target) if target
-              targets.each do |file|
-                sub = sub.with_option('-target', file)
-              end
-              sub = sub.with_option('-state', state) if state
-              sub = sub.with_option('-out', plan) if plan
-              sub = sub.with_option('-input', input) if input
-              sub = sub.with_flag('-destroy') if destroy
-              sub = sub.with_flag('-no-color') if no_color
-              sub
-            end
-            .with_argument(directory)
+      def command_line_commands(_option_values)
+        'plan'
+      end
+
+      def option_default_values(_opts)
+        { vars: {}, var_files: [], targets: [] }
+      end
+
+      def command_line_arguments(option_values)
+        option_values[:directory]
       end
     end
   end

--- a/lib/ruby_terraform/commands/plan.rb
+++ b/lib/ruby_terraform/commands/plan.rb
@@ -8,9 +8,9 @@ module RubyTerraform
         RubyTerraform::CommandLine::Options.new(
           option_values: option_values,
           command_arguments: {
-            standard: %i[state target var_file],
-            boolean: %i[input],
-            flags: %i[destroy no_color],
+            standard: %i[lock_timeout parallelism state target var var_file],
+            boolean: %i[input lock refresh],
+            flags: %i[compact_warnings destroy detailed_exitcode no_color],
             switch_overrides: { vars: '-var', targets: '-target', var_files: '-var-file', plan: '-out' }
           }
         )

--- a/lib/ruby_terraform/commands/refresh.rb
+++ b/lib/ruby_terraform/commands/refresh.rb
@@ -1,41 +1,31 @@
-require 'json'
 require_relative 'base'
+require_relative '../command_line/options'
 
 module RubyTerraform
   module Commands
     class Refresh < Base
-      def configure_command(builder, opts)
-        directory = opts[:directory]
-        vars = opts[:vars] || {}
-        var_file = opts[:var_file]
-        var_files = opts[:var_files] || []
-        state = opts[:state]
-        input = opts[:input]
-        target = opts[:target]
-        targets = opts[:targets] || []
-        no_color = opts[:no_color]
+      def command_line_options(option_values)
+        RubyTerraform::CommandLine::Options.new(
+          option_values: option_values,
+          command_arguments: {
+            standard: %i[state target var_file],
+            boolean: %i[input],
+            flags: %i[no_color],
+            switch_overrides: { targets: '-target', vars: '-var', var_files: '-var-file' }
+          }
+        )
+      end
 
-        builder
-            .with_subcommand('refresh') do |sub|
-              vars.each do |key, value|
-                var_value = value.is_a?(String) ? value : JSON.generate(value)
-                sub = sub.with_option(
-                    '-var', "'#{key}=#{var_value}'", separator: ' ')
-              end
-              sub = sub.with_option('-var-file', var_file) if var_file
-              var_files.each do |file|
-                sub = sub.with_option('-var-file', file)
-              end
-              sub = sub.with_option('-state', state) if state
-              sub = sub.with_option('-input', input) if input
-              sub = sub.with_option('-target', target) if target
-              targets.each do |target_name|
-                sub = sub.with_option('-target', target_name)
-              end
-              sub = sub.with_flag('-no-color') if no_color
-              sub
-            end
-            .with_argument(directory)
+      def command_line_commands(_option_values)
+        'refresh'
+      end
+
+      def command_line_arguments(option_values)
+        option_values[:directory]
+      end
+
+      def option_default_values(_opts)
+        { vars: {}, var_files: [], targets: [] }
       end
     end
   end

--- a/lib/ruby_terraform/commands/refresh.rb
+++ b/lib/ruby_terraform/commands/refresh.rb
@@ -8,9 +8,9 @@ module RubyTerraform
         RubyTerraform::CommandLine::Options.new(
           option_values: option_values,
           command_arguments: {
-            standard: %i[state target var_file],
+            standard: %i[backup lock_timeout state state_out target var var_file],
             boolean: %i[input],
-            flags: %i[no_color],
+            flags: %i[compact_warnings lock no_color],
             switch_overrides: { targets: '-target', vars: '-var', var_files: '-var-file' }
           }
         )

--- a/lib/ruby_terraform/commands/remote_config.rb
+++ b/lib/ruby_terraform/commands/remote_config.rb
@@ -1,25 +1,25 @@
 require_relative 'base'
+require_relative '../command_line/options'
 
 module RubyTerraform
   module Commands
     class RemoteConfig < Base
-      def configure_command(builder, opts)
-        backend = opts[:backend]
-        no_color = opts[:no_color]
-        backend_config = opts[:backend_config] || {}
+      def command_line_options(option_values)
+        RubyTerraform::CommandLine::Options.new(
+          option_values: option_values,
+          command_arguments: {
+            standard: %i[backend backend_config],
+            flags: %i[no_color]
+          }
+        )
+      end
 
-        builder
-            .with_subcommand('remote')
-            .with_subcommand('config') do |sub|
-              sub = sub.with_option('-backend', backend) if backend
-              backend_config.each do |key, value|
-                sub = sub.with_option(
-                    '-backend-config', "'#{key}=#{value}'", separator: ' ')
-              end
+      def command_line_commands(_option_values)
+        %w[remote config]
+      end
 
-              sub = sub.with_flag('-no-color') if no_color
-              sub
-            end
+      def option_default_values(_opts)
+        { backend_config: {} }
       end
     end
   end

--- a/lib/ruby_terraform/commands/show.rb
+++ b/lib/ruby_terraform/commands/show.rb
@@ -1,24 +1,26 @@
 # frozen_string_literal: true
 
 require_relative 'base'
+require_relative '../command_line/options'
 
 module RubyTerraform
   module Commands
     class Show < Base
-      def configure_command(builder, opts)
-        path = opts[:path] || opts[:directory]
-        json_format = opts[:json]
-        no_color = opts[:no_color]
-        module_depth = opts[:module_depth]
+      def command_line_options(option_values)
+        RubyTerraform::CommandLine::Options.new(
+          option_values: option_values,
+          command_arguments: {
+            flags: %i[json no_color]
+          }
+        )
+      end
 
-        builder
-          .with_subcommand('show') do |sub|
-          sub = sub.with_option('-module-depth', module_depth) if module_depth
-          sub = sub.with_flag('-no-color') if no_color
-          sub = sub.with_flag('-json') if json_format
-          sub
-        end
-          .with_argument(path)
+      def command_line_commands(_option_values)
+        'show'
+      end
+
+      def command_line_arguments(option_values)
+        option_values[:path] || option_values[:directory]
       end
     end
   end

--- a/lib/ruby_terraform/commands/validate.rb
+++ b/lib/ruby_terraform/commands/validate.rb
@@ -1,38 +1,31 @@
-require 'json'
 require_relative 'base'
+require_relative '../command_line/options'
 
 module RubyTerraform
   module Commands
     class Validate < Base
-      def configure_command(builder, opts)
-        directory = opts[:directory]
-        vars = opts[:vars] || {}
-        var_file = opts[:var_file]
-        var_files = opts[:var_files] || []
-        state = opts[:state]
-        check_variables = opts[:check_variables]
-        no_color = opts[:no_color]
-        json_format = opts[:json]
+      def command_line_options(option_values)
+        RubyTerraform::CommandLine::Options.new(
+          option_values: option_values,
+          command_arguments: {
+            standard: %i[state var_file],
+            boolean: %i[check_variables],
+            flags: %i[json no_color],
+            switch_overrides: { vars: '-var', var_files: '-var-file' }
+          }
+        )
+      end
 
-        builder
-            .with_subcommand('validate') do |sub|
-              vars.each do |key, value|
-                var_value = value.is_a?(String) ? value : JSON.generate(value)
-                sub = sub.with_option(
-                    '-var', "'#{key}=#{var_value}'", separator: ' ')
-              end
-              sub = sub.with_option('-var-file', var_file) if var_file
-              var_files.each do |file|
-                sub = sub.with_option('-var-file', file)
-              end
-              sub = sub.with_option('-state', state) if state
-              sub = sub.with_option('-check-variables', check_variables) unless
-                  check_variables.nil?
-              sub = sub.with_flag('-no-color') if no_color
-              sub = sub.with_flag('-json') if json_format
-              sub
-            end
-            .with_argument(directory)
+      def command_line_commands(_option_values)
+        'validate'
+      end
+
+      def command_line_arguments(option_values)
+        option_values[:directory]
+      end
+
+      def option_default_values(_opts)
+        { vars: {}, var_files: [] }
       end
     end
   end

--- a/lib/ruby_terraform/commands/validate.rb
+++ b/lib/ruby_terraform/commands/validate.rb
@@ -8,10 +8,7 @@ module RubyTerraform
         RubyTerraform::CommandLine::Options.new(
           option_values: option_values,
           command_arguments: {
-            standard: %i[state var_file],
-            boolean: %i[check_variables],
-            flags: %i[json no_color],
-            switch_overrides: { vars: '-var', var_files: '-var-file' }
+            flags: %i[json no_color]
           }
         )
       end

--- a/lib/ruby_terraform/commands/workspace.rb
+++ b/lib/ruby_terraform/commands/workspace.rb
@@ -3,20 +3,19 @@ require_relative 'base'
 module RubyTerraform
   module Commands
     class Workspace < Base
-      def configure_command(builder, opts)
-        directory = opts[:directory] || nil
-        operation = opts[:operation] || 'list'
-        workspace = opts[:workspace] || nil
+      def command_line_commands(option_values)
+        command_line_commands = ['workspace', option_values[:operation]]
+        return command_line_commands unless option_values[:workspace] && option_values[:operation] != 'list'
 
-        builder = builder
-            .with_subcommand('workspace')
-            .with_subcommand(operation)
+        command_line_commands << option_values[:workspace]
+      end
 
-        builder = builder.with_subcommand(workspace) if
-            workspace && operation != 'list'
-        builder = builder.with_argument(directory)
+      def command_line_arguments(option_values)
+        option_values[:directory]
+      end
 
-        builder
+      def option_default_values(_opts)
+        { directory: nil, operation: 'list', workspace: nil }
       end
     end
   end

--- a/spec/ruby_terraform/command_line/boolean_option_spec.rb
+++ b/spec/ruby_terraform/command_line/boolean_option_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+require_relative '../../../lib/ruby_terraform/command_line/boolean_option'
+
+module RubyTerraform
+  module CommandLine
+    describe BooleanOption do
+      subject(:command_line_option) { described_class.new(opt_key, value, options) }
+
+      let(:opt_key) { :snake_key }
+      let(:value) { true }
+      let(:options) { {} }
+      let(:sub) { instance_double(Lino::SubcommandBuilder) }
+      let(:add_to_subcommand) { command_line_option.add_to_subcommand(sub) }
+
+      before do
+        allow(sub).to receive(:with_option).and_return(sub)
+        add_to_subcommand
+      end
+
+      describe '.new' do
+        it_behaves_like 'an option that derives the command switch'
+
+        it_behaves_like 'an option that converts its value to a boolean'
+      end
+
+      describe '#add_to_subcommand' do
+        context 'when the option value is true' do
+          it 'adds the option=true to the terraform command line' do
+            expect(sub).to have_received(:with_option).with('-snake-key', true)
+          end
+
+          context 'when the option value is false' do
+            let(:value) { false }
+
+            it 'adds the option=false to the terraform command line' do
+              expect(sub).to have_received(:with_option).with('-snake-key', false)
+            end
+          end
+
+          context 'when the option value is nil' do
+            let(:value) { nil }
+
+            it 'does not add the switch to the terraform command line' do
+              expect(sub).not_to have_received(:with_option)
+            end
+          end
+
+          it 'returns the altered subcommand' do
+            expect(add_to_subcommand).to eq(sub)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ruby_terraform/command_line/builder_spec.rb
+++ b/spec/ruby_terraform/command_line/builder_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+require_relative '../../../lib/ruby_terraform/command_line/builder'
+require_relative '../../../lib/ruby_terraform/command_line/options'
+
+describe RubyTerraform::CommandLine::Builder do
+  subject(:command_line_builder) do
+    described_class.new(
+      binary: binary,
+      command_line_commands: command_line_commands,
+      command_line_options: command_line_options,
+      command_line_arguments: command_line_arguments
+    )
+  end
+
+  let(:binary) { 'terraform' }
+  let(:first_command) { 'remote' }
+  let(:last_command) { 'config' }
+  let(:command_line_commands) { [first_command, last_command] }
+  let(:command_line_arguments) { '/argument/one' }
+  let(:command_line_options) { instance_double(RubyTerraform::CommandLine::Options, each: nil) }
+  let(:command_line_option) { instance_double(RubyTerraform::CommandLine::Option) }
+  let(:built_command) { "#{binary} #{command_line_commands} #{command_line_arguments}" }
+  let(:lino_builder) { instance_double(Lino::CommandLineBuilder) }
+  let(:lino_subcommand_builder) { instance_double(Lino::SubcommandBuilder) }
+
+  before do
+    allow(Lino::CommandLineBuilder).to receive(:for_command).and_return(lino_builder)
+    allow(lino_builder).to receive(:with_option_separator).and_return(lino_builder)
+    allow(lino_builder).to receive(:with_subcommand).with(first_command).and_return(lino_builder)
+    allow(lino_builder).to receive(:with_subcommand).with(last_command).and_return(lino_builder).and_yield(lino_subcommand_builder)
+    allow(lino_builder).to receive(:with_argument).and_return(lino_builder)
+    allow(lino_builder).to receive(:build).and_return(built_command)
+    allow(command_line_options).to receive(:inject).and_yield(lino_subcommand_builder, command_line_option)
+    allow(command_line_option).to receive(:add_to_subcommand).and_return(lino_subcommand_builder)
+    command_line_builder
+  end
+
+  describe '.new' do
+    it 'creates a lino command line builder for the supplied binary' do
+      expect(Lino::CommandLineBuilder).to have_received(:for_command).with(binary)
+    end
+
+    it 'sets the lino command line builder option separator to be =' do
+      expect(lino_builder).to have_received(:with_option_separator).with('=')
+    end
+
+    context 'when the supplied command_line_commands is a single command' do
+      let(:command_line_commands) { 'test' }
+
+      it 'converts the command to an array' do
+        expect(command_line_builder.instance_variable_get(:@command_line_commands)).to eq([command_line_commands])
+      end
+    end
+
+    context 'when the supplied command_line_arguments is a single argument' do
+      let(:command_line_arguments) { 'test' }
+
+      it 'converts the argument to an array' do
+        expect(command_line_builder.instance_variable_get(:@command_line_arguments)).to eq([command_line_arguments])
+      end
+    end
+  end
+
+  describe '#build' do
+    before { command_line_builder.build }
+
+    it 'adds a Lino sub command for each command line command' do
+      expect(lino_builder).to have_received(:with_subcommand).with(command_line_commands.first)
+    end
+
+    it 'associates Lino options with the last command line command' do
+      expect(lino_builder).to have_received(:with_subcommand).with(command_line_commands.last)
+    end
+
+    it 'adds a Lino option/flag to the sub command for each command line option' do
+      expect(command_line_option).to have_received(:add_to_subcommand).with(lino_subcommand_builder)
+    end
+
+    it 'adds a Lino argument to the sub command for each command line argument' do
+      expect(lino_builder).to have_received(:with_argument).with(command_line_arguments)
+    end
+
+    context 'when the argument value is nil' do
+      let(:command_line_arguments) { nil }
+
+      it 'does not add the Lino argument to the sub command' do
+        expect(lino_builder).not_to have_received(:with_argument).with(command_line_arguments)
+      end
+    end
+
+    it 'requests the Lino CommandLineBuilder build the command line  ' do
+      expect(lino_builder).to have_received(:build)
+    end
+
+    it 'returns the built command' do
+      expect(command_line_builder.build).to eq(built_command)
+    end
+  end
+end

--- a/spec/ruby_terraform/command_line/flag_spec.rb
+++ b/spec/ruby_terraform/command_line/flag_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+require_relative '../../../lib/ruby_terraform/command_line/flag'
+
+module RubyTerraform
+  module CommandLine
+    describe Flag do
+      subject(:command_line_option) { described_class.new(opt_key, value, options) }
+
+      let(:opt_key) { :snake_key }
+      let(:value) { true }
+      let(:options) { {} }
+      let(:sub) { instance_double(Lino::SubcommandBuilder) }
+      let(:add_to_subcommand) { command_line_option.add_to_subcommand(sub) }
+
+      before do
+        allow(sub).to receive(:with_flag).and_return(sub)
+        add_to_subcommand
+      end
+
+      describe '.new' do
+        it_behaves_like 'an option that derives the command switch'
+
+        it_behaves_like 'an option that converts its value to a boolean'
+      end
+
+      describe '#add_to_subcommand' do
+        context 'when the option value is true' do
+          it 'adds the switch to the terraform command line' do
+            expect(sub).to have_received(:with_flag).with('-snake-key',)
+          end
+
+          context 'when the option value is false' do
+            let(:value) { false }
+
+            it 'does not add the switch to the terraform command line' do
+              expect(sub).not_to have_received(:with_flag)
+            end
+          end
+
+          context 'when the option value is nil' do
+            let(:value) { nil }
+
+            it 'does not add the switch to the terraform command line' do
+              expect(sub).not_to have_received(:with_flag)
+            end
+          end
+
+          it 'returns the altered subcommand' do
+            expect(add_to_subcommand).to eq(sub)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ruby_terraform/command_line/option_spec.rb
+++ b/spec/ruby_terraform/command_line/option_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+require_relative '../../../lib/ruby_terraform/command_line/option'
+
+module RubyTerraform
+  module CommandLine
+    describe Option do
+      subject(:command_line_option) { described_class.new(opt_key, value, options) }
+
+      let(:opt_key) { :snake_key }
+      let(:value) { 'some/state.tfstate' }
+      let(:options) { {} }
+      let(:sub) { instance_double(Lino::SubcommandBuilder) }
+      let(:add_to_subcommand) { command_line_option.add_to_subcommand(sub) }
+
+      before do
+        allow(JSON).to receive(:generate).and_call_original
+        allow(sub).to receive(:with_option).and_return(sub)
+        add_to_subcommand
+      end
+
+      describe '.new' do
+        it_behaves_like 'an option that derives the command switch'
+      end
+
+      describe '#add_to_subcommand' do
+        it 'returns the altered subcommand' do
+          expect(add_to_subcommand).to eq(sub)
+        end
+
+        context 'when the option value is a single value' do
+          context 'when the option does not contain boolean values' do
+            context 'when the option value is populated / true' do
+              let(:value) { true }
+
+              it 'calls the SubcommandBuilder with_option with the switch and value' do
+                expect(sub).to have_received(:with_option).with('-snake-key', value)
+              end
+            end
+
+            context 'when the option value is false' do
+              let(:value) { false }
+
+              it 'does not call the SubcommandBuilder with_option' do
+                expect(sub).not_to have_received(:with_option)
+              end
+            end
+
+            context 'when the option value is nil' do
+              let(:value) { nil }
+
+              it 'does not call the SubcommandBuilder with_option' do
+                expect(sub).not_to have_received(:with_option)
+              end
+            end
+          end
+        end
+
+        context 'when the option value responds to keys' do
+          let(:value) { { key: 'value', another: 'value' } }
+
+          it 'calls the SubcommandBuilder with_option for each key value pair' do
+            expect(sub).to have_received(:with_option).with('-snake-key', "'key=value'", anything)
+            expect(sub).to have_received(:with_option).with('-snake-key', "'another=value'", anything)
+          end
+
+          it 'specifies the separator is a single space' do
+            expect(sub).to have_received(:with_option).with(anything, anything, { separator: ' ' }).twice
+          end
+
+          context 'when the values within the option value are not strings' do
+            let(:value) { { key: 123 } }
+
+            it 'uses JSON.generate to convert the value to a string' do
+              expect(JSON).to have_received(:generate).with(123)
+            end
+
+            it 'calls the SubcommandBuilder with_option with the converted value' do
+              expect(sub).to have_received(:with_option).with('-snake-key', "'key=123'", anything)
+            end
+          end
+        end
+
+        context 'when the option value responds to each' do
+          let(:value) { %w[some/state.tfstate another/state.tfstate] }
+
+          it 'calls the SubcommandBuilder with_option for each value' do
+            expect(sub).to have_received(:with_option).with('-snake-key', 'some/state.tfstate')
+            expect(sub).to have_received(:with_option).with('-snake-key', 'another/state.tfstate')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ruby_terraform/command_line/options_spec.rb
+++ b/spec/ruby_terraform/command_line/options_spec.rb
@@ -21,23 +21,28 @@ module RubyTerraform
 
       let(:option_values) do
         {
+          my_global => my_global_value,
           my_option: my_option_value,
           my_flag: my_flag_value,
           my_boolean: my_boolean_value,
           my_override: my_override_value
         }
       end
+      let(:my_global) { Options.global_options.first}
+      let(:my_global_value) { 'value' }
       let(:my_option_value) { 'value' }
       let(:my_flag_value) { true }
       let(:my_boolean_value) { true }
       let(:my_override_value) { 'value' }
       let(:switch_override) { '-different-switch' }
+      let(:command_line_global) { instance_double(Option) }
       let(:command_line_option) { instance_double(Option) }
       let(:command_line_override) { instance_double(Option) }
       let(:command_line_flag) { instance_double(Flag) }
       let(:command_line_boolean) { instance_double(BooleanOption) }
 
       before do
+        allow(Option).to receive(:new).with(my_global, any_args).and_return(command_line_global)
         allow(Option).to receive(:new).with(:my_option, any_args).and_return(command_line_option)
         allow(Flag).to receive(:new).with(:my_flag, any_args).and_return(command_line_flag)
         allow(BooleanOption).to receive(:new).with(:my_boolean, any_args).and_return(command_line_boolean)
@@ -48,6 +53,10 @@ module RubyTerraform
       describe '.new' do
         it 'creates a CommandLineOption with an overridden switch for each switch_overrides' do
           expect(Option).to have_received(:new).with(:my_override, my_override_value, switch_override: switch_override)
+        end
+
+        it 'creates a CommandLineOption option for each global option' do
+          expect(Option).to have_received(:new).with(my_global, my_global_value, switch_override: nil)
         end
 
         it 'creates a CommandLineOption option for each standard option' do
@@ -63,7 +72,7 @@ module RubyTerraform
         end
 
         it 'populates the array with the created command line options' do
-          expect(command_line_options).to eq([command_line_override, command_line_option, command_line_boolean, command_line_flag])
+          expect(command_line_options).to eq([command_line_override, command_line_global, command_line_option, command_line_boolean, command_line_flag])
         end
       end
     end

--- a/spec/ruby_terraform/command_line/options_spec.rb
+++ b/spec/ruby_terraform/command_line/options_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+require_relative '../../../lib/ruby_terraform/command_line/options'
+require_relative '../../../lib/ruby_terraform/command_line/option'
+require_relative '../../../lib/ruby_terraform/command_line/flag'
+require_relative '../../../lib/ruby_terraform/command_line/boolean_option'
+
+module RubyTerraform
+  module CommandLine
+    describe Options do
+      subject(:command_line_options) do
+        described_class.new(
+          option_values: option_values,
+          command_arguments: {
+            standard: %i[my_option],
+            boolean: %i[my_boolean],
+            flags: %i[my_flag],
+            switch_overrides: { my_override: switch_override }
+          }
+        )
+      end
+
+      let(:option_values) do
+        {
+          my_option: my_option_value,
+          my_flag: my_flag_value,
+          my_boolean: my_boolean_value,
+          my_override: my_override_value
+        }
+      end
+      let(:my_option_value) { 'value' }
+      let(:my_flag_value) { true }
+      let(:my_boolean_value) { true }
+      let(:my_override_value) { 'value' }
+      let(:switch_override) { '-different-switch' }
+      let(:command_line_option) { instance_double(Option) }
+      let(:command_line_override) { instance_double(Option) }
+      let(:command_line_flag) { instance_double(Flag) }
+      let(:command_line_boolean) { instance_double(BooleanOption) }
+
+      before do
+        allow(Option).to receive(:new).with(:my_option, any_args).and_return(command_line_option)
+        allow(Flag).to receive(:new).with(:my_flag, any_args).and_return(command_line_flag)
+        allow(BooleanOption).to receive(:new).with(:my_boolean, any_args).and_return(command_line_boolean)
+        allow(Option).to receive(:new).with(:my_override, any_args).and_return(command_line_override)
+        command_line_options
+      end
+
+      describe '.new' do
+        it 'creates a CommandLineOption with an overridden switch for each switch_overrides' do
+          expect(Option).to have_received(:new).with(:my_override, my_override_value, switch_override: switch_override)
+        end
+
+        it 'creates a CommandLineOption option for each standard option' do
+          expect(Option).to have_received(:new).with(:my_option, my_option_value, switch_override: nil)
+        end
+
+        it 'creates a Flag for each flag option' do
+          expect(Flag).to have_received(:new).with(:my_flag, my_flag_value)
+        end
+
+        it 'creates a BooleanOption for each boolean option' do
+          expect(BooleanOption).to have_received(:new).with(:my_boolean, my_boolean_value)
+        end
+
+        it 'populates the array with the created command line options' do
+          expect(command_line_options).to eq([command_line_override, command_line_option, command_line_boolean, command_line_flag])
+        end
+      end
+    end
+  end
+end

--- a/spec/ruby_terraform/commands/apply_spec.rb
+++ b/spec/ruby_terraform/commands/apply_spec.rb
@@ -39,6 +39,10 @@ describe RubyTerraform::Commands::Apply do
 
   it_behaves_like 'a command with a boolean option', [terraform_command, :input, terraform_config_path]
 
+  it_behaves_like 'a command with a boolean option', [terraform_command, :lock, terraform_config_path]
+
+  it_behaves_like 'a command with a boolean option', [terraform_command, :refresh, terraform_config_path]
+
   it_behaves_like 'a command with an array option', [terraform_command, :targets, terraform_config_path]
 
   it_behaves_like 'a command with an array option', [terraform_command, :var_files, terraform_config_path]
@@ -47,5 +51,15 @@ describe RubyTerraform::Commands::Apply do
 
   it_behaves_like 'a command with an option', [terraform_command, :state, terraform_config_path]
 
+  it_behaves_like 'a command with an option', [terraform_command, :chdir, terraform_config_path]
+
+  it_behaves_like 'a command with an option', [terraform_command, :lock_timeout, terraform_config_path]
+
+  it_behaves_like 'a command with an option', [terraform_command, :parallelism, terraform_config_path]
+
+  it_behaves_like 'a command with an option', [terraform_command, :state_out, terraform_config_path]
+
   it_behaves_like 'a command with a flag', [terraform_command, :no_color, terraform_config_path]
+
+  it_behaves_like 'a command with a flag', [terraform_command, :compact_warnings, terraform_config_path]
 end

--- a/spec/ruby_terraform/commands/apply_spec.rb
+++ b/spec/ruby_terraform/commands/apply_spec.rb
@@ -23,6 +23,8 @@ describe RubyTerraform::Commands::Apply do
                plan: 'some/path/to/terraform/plan' }
   }
 
+  it_behaves_like 'a command that accepts global options', [terraform_command, terraform_config_path]
+
   it_behaves_like 'a command with an argument', [terraform_command, :directory]
 
   it_behaves_like 'a command with an argument', [terraform_command, :plan]

--- a/spec/ruby_terraform/commands/apply_spec.rb
+++ b/spec/ruby_terraform/commands/apply_spec.rb
@@ -16,10 +16,6 @@ describe RubyTerraform::Commands::Apply do
   terraform_command = 'apply'
   terraform_config_path = Faker::File.dir
 
-  it_behaves_like 'a command with an argument', [terraform_command, :directory]
-
-  it_behaves_like 'a command with an argument', [terraform_command, :plan]
-
   it_behaves_like 'a valid command line', {
     reason: 'prefers the plan if both plan and directory provided',
     expected_command: 'terraform apply some/path/to/terraform/plan',
@@ -27,23 +23,27 @@ describe RubyTerraform::Commands::Apply do
                plan: 'some/path/to/terraform/plan' }
   }
 
+  it_behaves_like 'a command with an argument', [terraform_command, :directory]
+
+  it_behaves_like 'a command with an argument', [terraform_command, :plan]
+
   it_behaves_like 'a command without a binary supplied', [terraform_command, described_class, terraform_config_path]
 
   it_behaves_like 'a command that accepts vars', [terraform_command, terraform_config_path]
 
-  it_behaves_like 'a command with an option', [terraform_command, :state, terraform_config_path]
-
-  it_behaves_like 'a command with an option', [terraform_command, :backup, terraform_config_path]
-
   it_behaves_like 'a command that can disable backup', [terraform_command, terraform_config_path]
-
-  it_behaves_like 'a command with a flag', [terraform_command, :no_color, terraform_config_path]
-
-  it_behaves_like 'a command with an array option', [terraform_command, :var_files, terraform_config_path]
 
   it_behaves_like 'a command with a boolean option', [terraform_command, :auto_approve, terraform_config_path]
 
-  it_behaves_like 'a command with an option', [terraform_command, :input, terraform_config_path]
+  it_behaves_like 'a command with a boolean option', [terraform_command, :input, terraform_config_path]
 
   it_behaves_like 'a command with an array option', [terraform_command, :targets, terraform_config_path]
+
+  it_behaves_like 'a command with an array option', [terraform_command, :var_files, terraform_config_path]
+
+  it_behaves_like 'a command with an option', [terraform_command, :backup, terraform_config_path]
+
+  it_behaves_like 'a command with an option', [terraform_command, :state, terraform_config_path]
+
+  it_behaves_like 'a command with a flag', [terraform_command, :no_color, terraform_config_path]
 end

--- a/spec/ruby_terraform/commands/destroy_spec.rb
+++ b/spec/ruby_terraform/commands/destroy_spec.rb
@@ -23,19 +23,19 @@ describe RubyTerraform::Commands::Destroy do
 
   it_behaves_like 'a command that accepts vars', [terraform_command, terraform_config_path]
 
-  it_behaves_like 'a command with an option', [terraform_command, :state, terraform_config_path]
-
-  it_behaves_like 'a command with an option', [terraform_command, :backup, terraform_config_path]
-
   it_behaves_like 'a command that can disable backup', [terraform_command, terraform_config_path]
 
-  it_behaves_like 'a command with a flag', [terraform_command, :no_color, terraform_config_path]
-
-  it_behaves_like 'a command with a flag', [terraform_command, :force, terraform_config_path]
-
-  it_behaves_like 'a command with an array option', [terraform_command, :var_files, terraform_config_path]
+  it_behaves_like 'a command with a boolean option', [terraform_command, :auto_approve, terraform_config_path]
 
   it_behaves_like 'a command with an array option', [terraform_command, :targets, terraform_config_path]
 
-  it_behaves_like 'a command with a boolean option', [terraform_command, :auto_approve, terraform_config_path]
+  it_behaves_like 'a command with an array option', [terraform_command, :var_files, terraform_config_path]
+
+  it_behaves_like 'a command with an option', [terraform_command, :backup, terraform_config_path]
+
+  it_behaves_like 'a command with an option', [terraform_command, :state, terraform_config_path]
+
+  it_behaves_like 'a command with a flag', [terraform_command, :force, terraform_config_path]
+
+  it_behaves_like 'a command with a flag', [terraform_command, :no_color, terraform_config_path]
 end

--- a/spec/ruby_terraform/commands/destroy_spec.rb
+++ b/spec/ruby_terraform/commands/destroy_spec.rb
@@ -17,6 +17,8 @@ describe RubyTerraform::Commands::Destroy do
   terraform_command = 'destroy'
   terraform_config_path = Faker::File.dir
 
+  it_behaves_like 'a command that accepts global options', [terraform_command, terraform_config_path]
+
   it_behaves_like 'a command with an argument', [terraform_command, :directory]
 
   it_behaves_like 'a command without a binary supplied', [terraform_command, described_class, terraform_config_path]

--- a/spec/ruby_terraform/commands/destroy_spec.rb
+++ b/spec/ruby_terraform/commands/destroy_spec.rb
@@ -29,13 +29,23 @@ describe RubyTerraform::Commands::Destroy do
 
   it_behaves_like 'a command with a boolean option', [terraform_command, :auto_approve, terraform_config_path]
 
+  it_behaves_like 'a command with a boolean option', [terraform_command, :lock, terraform_config_path]
+
+  it_behaves_like 'a command with a boolean option', [terraform_command, :refresh, terraform_config_path]
+
   it_behaves_like 'a command with an array option', [terraform_command, :targets, terraform_config_path]
 
   it_behaves_like 'a command with an array option', [terraform_command, :var_files, terraform_config_path]
 
   it_behaves_like 'a command with an option', [terraform_command, :backup, terraform_config_path]
 
+  it_behaves_like 'a command with an option', [terraform_command, :lock_timeout, terraform_config_path]
+
+  it_behaves_like 'a command with an option', [terraform_command, :parallelism, terraform_config_path]
+
   it_behaves_like 'a command with an option', [terraform_command, :state, terraform_config_path]
+
+  it_behaves_like 'a command with an option', [terraform_command, :state_out, terraform_config_path]
 
   it_behaves_like 'a command with a flag', [terraform_command, :force, terraform_config_path]
 

--- a/spec/ruby_terraform/commands/format_spec.rb
+++ b/spec/ruby_terraform/commands/format_spec.rb
@@ -22,15 +22,15 @@ describe RubyTerraform::Commands::Format do
 
   it_behaves_like 'a command without a binary supplied', [terraform_command, described_class, terraform_config_path]
 
-  it_behaves_like 'a command with a flag', [terraform_command, :no_color, terraform_config_path]
+  it_behaves_like 'a command with a boolean option', [terraform_command, :list, terraform_config_path]
+
+  it_behaves_like 'a command with a boolean option', [terraform_command, :write, terraform_config_path]
 
   it_behaves_like 'a command with a flag', [terraform_command, :check, terraform_config_path]
 
   it_behaves_like 'a command with a flag', [terraform_command, :diff, terraform_config_path]
 
-  it_behaves_like 'a command with an option', [terraform_command, :list, terraform_config_path]
+  it_behaves_like 'a command with a flag', [terraform_command, :no_color, terraform_config_path]
 
   it_behaves_like 'a command with a flag', [terraform_command, :recursive, terraform_config_path]
-
-  it_behaves_like 'a command with an option', [terraform_command, :write, terraform_config_path]
 end

--- a/spec/ruby_terraform/commands/format_spec.rb
+++ b/spec/ruby_terraform/commands/format_spec.rb
@@ -18,6 +18,8 @@ describe RubyTerraform::Commands::Format do
   terraform_command = 'fmt'
   terraform_config_path = Faker::File.dir
 
+  it_behaves_like 'a command that accepts global options', [terraform_command, terraform_config_path]
+
   it_behaves_like 'a command with an argument', [terraform_command, :directory]
 
   it_behaves_like 'a command without a binary supplied', [terraform_command, described_class, terraform_config_path]

--- a/spec/ruby_terraform/commands/get_spec.rb
+++ b/spec/ruby_terraform/commands/get_spec.rb
@@ -16,6 +16,8 @@ describe RubyTerraform::Commands::Get do
   terraform_command = 'get'
   terraform_config_path = Faker::File.dir
 
+  it_behaves_like 'a command that accepts global options', [terraform_command, terraform_config_path]
+
   it_behaves_like 'a command with an argument', [terraform_command, :directory]
 
   it_behaves_like 'a command without a binary supplied', [terraform_command, described_class, terraform_config_path]

--- a/spec/ruby_terraform/commands/get_spec.rb
+++ b/spec/ruby_terraform/commands/get_spec.rb
@@ -20,7 +20,7 @@ describe RubyTerraform::Commands::Get do
 
   it_behaves_like 'a command without a binary supplied', [terraform_command, described_class, terraform_config_path]
 
-  it_behaves_like 'a command with an option', [terraform_command, :update, terraform_config_path]
+  it_behaves_like 'a command with a flag', [terraform_command, :update, terraform_config_path]
 
   it_behaves_like 'a command with a flag', [terraform_command, :no_color, terraform_config_path]
 end

--- a/spec/ruby_terraform/commands/import_spec.rb
+++ b/spec/ruby_terraform/commands/import_spec.rb
@@ -87,6 +87,8 @@ describe RubyTerraform::Commands::Import do
     options: common_options.merge({ var_file: 'some/vars.tfvars', var_files: %w[some/vars1.tfvars some/vars2.tfvars] })
   }
 
+  it_behaves_like 'an import command that accepts global options'
+
   it_behaves_like 'an import command with a boolean option', :input
 
   it_behaves_like 'an import command with an option', :state

--- a/spec/ruby_terraform/commands/import_spec.rb
+++ b/spec/ruby_terraform/commands/import_spec.rb
@@ -61,9 +61,9 @@ describe RubyTerraform::Commands::Import do
     options: common_options.merge({ vars: { list_of_maps: [{ key: 'value' }, { key: 'value' }] } })
   }
 
-  it_behaves_like 'an import command with an option', { state: 'some/state.tfstate' }
+  it_behaves_like 'an import command with an option', :state
 
-  it_behaves_like 'an import command with an option', { backup: 'some/state.tfstate.backup' }
+  it_behaves_like 'an import command with an option', :backup
 
   it_behaves_like 'a valid command line', {
     reason: 'disables backup if no_backup is true',

--- a/spec/ruby_terraform/commands/import_spec.rb
+++ b/spec/ruby_terraform/commands/import_spec.rb
@@ -91,7 +91,15 @@ describe RubyTerraform::Commands::Import do
 
   it_behaves_like 'an import command with a boolean option', :input
 
+  it_behaves_like 'an import command with an option', :backup
+
+  it_behaves_like 'an import command with an option', :lock_timeout
+
   it_behaves_like 'an import command with an option', :state
 
-  it_behaves_like 'an import command with an option', :backup
+  it_behaves_like 'an import command with an option', :state_out
+
+  it_behaves_like 'an import command with a flag', :allow_missing_config
+
+  it_behaves_like 'an import command with a flag', :ignore_remote_version
 end

--- a/spec/ruby_terraform/commands/import_spec.rb
+++ b/spec/ruby_terraform/commands/import_spec.rb
@@ -61,10 +61,6 @@ describe RubyTerraform::Commands::Import do
     options: common_options.merge({ vars: { list_of_maps: [{ key: 'value' }, { key: 'value' }] } })
   }
 
-  it_behaves_like 'an import command with an option', :state
-
-  it_behaves_like 'an import command with an option', :backup
-
   it_behaves_like 'a valid command line', {
     reason: 'disables backup if no_backup is true',
     expected_command: "terraform import -config=#{common_options[:directory]} -backup=- #{common_options[:address]} #{common_options[:id]}",
@@ -87,9 +83,13 @@ describe RubyTerraform::Commands::Import do
 
   it_behaves_like 'a valid command line', {
     reason: 'ensures that var_file and var_files options work together',
-    expected_command: "terraform import -config=#{common_options[:directory]} -var-file=some/vars.tfvars -var-file=some/vars1.tfvars -var-file=some/vars2.tfvars #{common_options[:address]} #{common_options[:id]}",
+    expected_command: "terraform import -config=#{common_options[:directory]} -var-file=some/vars1.tfvars -var-file=some/vars2.tfvars -var-file=some/vars.tfvars #{common_options[:address]} #{common_options[:id]}",
     options: common_options.merge({ var_file: 'some/vars.tfvars', var_files: %w[some/vars1.tfvars some/vars2.tfvars] })
   }
 
   it_behaves_like 'an import command with a boolean option', :input
+
+  it_behaves_like 'an import command with an option', :state
+
+  it_behaves_like 'an import command with an option', :backup
 end

--- a/spec/ruby_terraform/commands/init_spec.rb
+++ b/spec/ruby_terraform/commands/init_spec.rb
@@ -27,11 +27,26 @@ describe RubyTerraform::Commands::Init do
 
   it_behaves_like 'a command with a boolean option', [terraform_command, :get]
 
+  it_behaves_like 'a command with a boolean option', [terraform_command, :get_plugins]
+
+  it_behaves_like 'a command with a boolean option', [terraform_command, :input]
+
+  it_behaves_like 'a command with a boolean option', [terraform_command, :lock]
+
+  it_behaves_like 'a command with a boolean option', [terraform_command, :upgrade]
+
+  it_behaves_like 'a command with a boolean option', [terraform_command, :verify_plugins]
+
   it_behaves_like 'a command with a map option', [terraform_command, :backend_config]
 
   it_behaves_like 'a command with an option', [terraform_command, :from_module]
 
+  it_behaves_like 'a command with an option', [terraform_command, :lock_timeout]
+
   it_behaves_like 'a command with an option', [terraform_command, :plugin_dir]
 
   it_behaves_like 'a command with a flag', [terraform_command, :no_color]
+
+  it_behaves_like 'a command with a flag', [terraform_command, :reconfigure]
+
 end

--- a/spec/ruby_terraform/commands/init_spec.rb
+++ b/spec/ruby_terraform/commands/init_spec.rb
@@ -15,6 +15,8 @@ describe RubyTerraform::Commands::Init do
 
   terraform_command = 'init'
 
+  it_behaves_like 'a command that accepts global options', terraform_command
+
   it_behaves_like 'a command with an argument', [terraform_command, :path]
 
   it_behaves_like 'a command without a binary supplied', [terraform_command, described_class]

--- a/spec/ruby_terraform/commands/init_spec.rb
+++ b/spec/ruby_terraform/commands/init_spec.rb
@@ -15,11 +15,15 @@ describe RubyTerraform::Commands::Init do
 
   terraform_command = 'init'
 
+  it_behaves_like 'a command with an argument', [terraform_command, :path]
+
   it_behaves_like 'a command without a binary supplied', [terraform_command, described_class]
 
-  it_behaves_like 'a command with a flag', [terraform_command, :no_color]
+  it_behaves_like 'a command with a boolean option', [terraform_command, :backend]
 
-  it_behaves_like 'a command with an option', [terraform_command, :force_copy]
+  it_behaves_like 'a command with a boolean option', [terraform_command, :force_copy]
+
+  it_behaves_like 'a command with a boolean option', [terraform_command, :get]
 
   it_behaves_like 'a command with a map option', [terraform_command, :backend_config]
 
@@ -27,9 +31,5 @@ describe RubyTerraform::Commands::Init do
 
   it_behaves_like 'a command with an option', [terraform_command, :plugin_dir]
 
-  it_behaves_like 'a command with an argument', [terraform_command, :path]
-
-  it_behaves_like 'a command with a boolean option', [terraform_command, :backend]
-
-  it_behaves_like 'a command with a boolean option', [terraform_command, :get]
+  it_behaves_like 'a command with a flag', [terraform_command, :no_color]
 end

--- a/spec/ruby_terraform/commands/output_spec.rb
+++ b/spec/ruby_terraform/commands/output_spec.rb
@@ -43,6 +43,8 @@ describe RubyTerraform::Commands::Output do
     expect(command.execute(name: 'some_output')).to(eq('OUTPUT'))
   end
 
+  it_behaves_like 'a command that accepts global options', terraform_command
+
   it_behaves_like 'a command with an argument', [terraform_command, :name]
 
   it_behaves_like 'a command without a binary supplied', [terraform_command, described_class]

--- a/spec/ruby_terraform/commands/output_spec.rb
+++ b/spec/ruby_terraform/commands/output_spec.rb
@@ -15,14 +15,6 @@ describe RubyTerraform::Commands::Output do
 
   terraform_command = 'output'
 
-  it_behaves_like 'a command without a binary supplied', [terraform_command, described_class]
-
-  it_behaves_like 'a command with an option', [terraform_command, :state]
-
-  it_behaves_like 'a command with an argument', [terraform_command, :name]
-
-  it_behaves_like 'a command with an option', [terraform_command, :module]
-
   it 'captures and returns the output of the command directly when no name is supplied' do
     string_io = double('string IO')
     allow(StringIO).to(receive(:new).and_return(string_io))
@@ -50,6 +42,14 @@ describe RubyTerraform::Commands::Output do
 
     expect(command.execute(name: 'some_output')).to(eq('OUTPUT'))
   end
+
+  it_behaves_like 'a command with an argument', [terraform_command, :name]
+
+  it_behaves_like 'a command without a binary supplied', [terraform_command, described_class]
+
+  it_behaves_like 'a command with an option', [terraform_command, :module]
+
+  it_behaves_like 'a command with an option', [terraform_command, :state]
 
   it_behaves_like 'a command with a flag', [terraform_command, :no_color]
 

--- a/spec/ruby_terraform/commands/plan_spec.rb
+++ b/spec/ruby_terraform/commands/plan_spec.rb
@@ -17,10 +17,6 @@ describe RubyTerraform::Commands::Plan do
   terraform_command = 'plan'
   terraform_config_path = Faker::File.dir
 
-  it_behaves_like 'a command with an argument', [terraform_command, :directory]
-
-  it_behaves_like 'a command without a binary supplied', [terraform_command, described_class, terraform_config_path]
-
   it 'logs the command being executed at debug level using the globally configured logger by default' do
     string_output = StringIO.new
     logger = Logger.new(string_output)
@@ -56,22 +52,6 @@ describe RubyTerraform::Commands::Plan do
       include('DEBUG').and(
         include("Running 'terraform plan some/path/to/terraform/configuration'.")))
   end
-
-  it_behaves_like 'a command that accepts vars', [terraform_command, terraform_config_path]
-
-  it_behaves_like 'a command with an option', [terraform_command, :state, terraform_config_path]
-
-  it_behaves_like 'a command with an option', [terraform_command, :plan, terraform_config_path, { switch_override: '-out' }]
-
-  it_behaves_like 'a command with a flag', [terraform_command, :no_color, terraform_config_path]
-
-  it_behaves_like 'a command with a flag', [terraform_command, :destroy, terraform_config_path]
-
-  it_behaves_like 'a command with an array option', [terraform_command, :var_files, terraform_config_path]
-
-  it_behaves_like 'a command with an option', [terraform_command, :input, terraform_config_path]
-
-  it_behaves_like 'a command with an array option', [terraform_command, :targets, terraform_config_path]
 
   it 'logs an error raised when running the command' do
     string_output = StringIO.new
@@ -127,4 +107,24 @@ describe RubyTerraform::Commands::Plan do
         .and_raise(Open4::SpawnError.new('cmd', $?), 'message')
     )
   end
+
+  it_behaves_like 'a command with an argument', [terraform_command, :directory]
+
+  it_behaves_like 'a command without a binary supplied', [terraform_command, described_class, terraform_config_path]
+
+  it_behaves_like 'a command that accepts vars', [terraform_command, terraform_config_path]
+
+  it_behaves_like 'a command with a boolean option', [terraform_command, :input, terraform_config_path]
+
+  it_behaves_like 'a command with an array option', [terraform_command, :targets, terraform_config_path]
+
+  it_behaves_like 'a command with an array option', [terraform_command, :var_files, terraform_config_path]
+
+  it_behaves_like 'a command with an option', [terraform_command, :plan, terraform_config_path, { switch_override: '-out' }]
+
+  it_behaves_like 'a command with an option', [terraform_command, :state, terraform_config_path]
+
+  it_behaves_like 'a command with a flag', [terraform_command, :destroy, terraform_config_path]
+
+  it_behaves_like 'a command with a flag', [terraform_command, :no_color, terraform_config_path]
 end

--- a/spec/ruby_terraform/commands/plan_spec.rb
+++ b/spec/ruby_terraform/commands/plan_spec.rb
@@ -118,15 +118,27 @@ describe RubyTerraform::Commands::Plan do
 
   it_behaves_like 'a command with a boolean option', [terraform_command, :input, terraform_config_path]
 
+  it_behaves_like 'a command with a boolean option', [terraform_command, :lock, terraform_config_path]
+
+  it_behaves_like 'a command with a boolean option', [terraform_command, :refresh, terraform_config_path]
+
   it_behaves_like 'a command with an array option', [terraform_command, :targets, terraform_config_path]
 
   it_behaves_like 'a command with an array option', [terraform_command, :var_files, terraform_config_path]
 
   it_behaves_like 'a command with an option', [terraform_command, :plan, terraform_config_path, { switch_override: '-out' }]
 
+  it_behaves_like 'a command with an option', [terraform_command, :lock_timeout, terraform_config_path]
+
+  it_behaves_like 'a command with an option', [terraform_command, :parallelism, terraform_config_path]
+
   it_behaves_like 'a command with an option', [terraform_command, :state, terraform_config_path]
 
+  it_behaves_like 'a command with a flag', [terraform_command, :compact_warnings, terraform_config_path]
+
   it_behaves_like 'a command with a flag', [terraform_command, :destroy, terraform_config_path]
+
+  it_behaves_like 'a command with a flag', [terraform_command, :detailed_exitcode, terraform_config_path]
 
   it_behaves_like 'a command with a flag', [terraform_command, :no_color, terraform_config_path]
 end

--- a/spec/ruby_terraform/commands/plan_spec.rb
+++ b/spec/ruby_terraform/commands/plan_spec.rb
@@ -108,6 +108,8 @@ describe RubyTerraform::Commands::Plan do
     )
   end
 
+  it_behaves_like 'a command that accepts global options', [terraform_command, terraform_config_path]
+
   it_behaves_like 'a command with an argument', [terraform_command, :directory]
 
   it_behaves_like 'a command without a binary supplied', [terraform_command, described_class, terraform_config_path]

--- a/spec/ruby_terraform/commands/refresh_spec.rb
+++ b/spec/ruby_terraform/commands/refresh_spec.rb
@@ -32,5 +32,17 @@ describe RubyTerraform::Commands::Refresh do
 
   it_behaves_like 'a command with an option', [terraform_command, :state, terraform_config_path]
 
+  it_behaves_like 'a command with an option', [terraform_command, :backup, terraform_config_path]
+
+  it_behaves_like 'a command with an option', [terraform_command, :lock_timeout, terraform_config_path]
+
+  it_behaves_like 'a command with an option', [terraform_command, :state, terraform_config_path]
+
+  it_behaves_like 'a command with an option', [terraform_command, :state_out]
+
+  it_behaves_like 'a command with a flag', [terraform_command, :compact_warnings, terraform_config_path]
+
+  it_behaves_like 'a command with a flag', [terraform_command, :lock, terraform_config_path]
+
   it_behaves_like 'a command with a flag', [terraform_command, :no_color, terraform_config_path]
 end

--- a/spec/ruby_terraform/commands/refresh_spec.rb
+++ b/spec/ruby_terraform/commands/refresh_spec.rb
@@ -16,6 +16,8 @@ describe RubyTerraform::Commands::Refresh do
   terraform_command = 'refresh'
   terraform_config_path = Faker::File.dir
 
+  it_behaves_like 'a command that accepts global options', [terraform_command, terraform_config_path]
+
   it_behaves_like 'a command with an argument', [terraform_command, :directory]
 
   it_behaves_like 'a command without a binary supplied', [terraform_command, described_class, terraform_config_path]

--- a/spec/ruby_terraform/commands/refresh_spec.rb
+++ b/spec/ruby_terraform/commands/refresh_spec.rb
@@ -22,11 +22,13 @@ describe RubyTerraform::Commands::Refresh do
 
   it_behaves_like 'a command that accepts vars', [terraform_command, terraform_config_path]
 
-  it_behaves_like 'a command with an option', [terraform_command, :state, terraform_config_path]
-
-  it_behaves_like 'a command with a flag', [terraform_command, :no_color, terraform_config_path]
+  it_behaves_like 'a command with a boolean option', [terraform_command, :input, terraform_config_path]
 
   it_behaves_like 'a command with an array option', [terraform_command, :var_files, terraform_config_path]
 
   it_behaves_like 'a command with an array option', [terraform_command, :targets, terraform_config_path]
+
+  it_behaves_like 'a command with an option', [terraform_command, :state, terraform_config_path]
+
+  it_behaves_like 'a command with a flag', [terraform_command, :no_color, terraform_config_path]
 end

--- a/spec/ruby_terraform/commands/remote_config_spec.rb
+++ b/spec/ruby_terraform/commands/remote_config_spec.rb
@@ -17,9 +17,9 @@ describe RubyTerraform::Commands::RemoteConfig do
 
   it_behaves_like 'a command without a binary supplied', [terraform_command, described_class]
 
-  it_behaves_like 'a command with an option', [terraform_command, :backend]
-
   it_behaves_like 'a command with a map option', [terraform_command, :backend_config]
+
+  it_behaves_like 'a command with an option', [terraform_command, :backend]
 
   it_behaves_like 'a command with a flag', [terraform_command, :no_color]
 end

--- a/spec/ruby_terraform/commands/remote_config_spec.rb
+++ b/spec/ruby_terraform/commands/remote_config_spec.rb
@@ -15,6 +15,8 @@ describe RubyTerraform::Commands::RemoteConfig do
 
   terraform_command = 'remote config'
 
+  it_behaves_like 'a command that accepts global options', terraform_command
+
   it_behaves_like 'a command without a binary supplied', [terraform_command, described_class]
 
   it_behaves_like 'a command with a map option', [terraform_command, :backend_config]

--- a/spec/ruby_terraform/commands/show_spec.rb
+++ b/spec/ruby_terraform/commands/show_spec.rb
@@ -16,11 +16,18 @@ describe RubyTerraform::Commands::Show do
   terraform_command = 'show'
   terraform_config_path = Faker::File.dir
 
+  it_behaves_like 'a valid command line', {
+    reason: 'prefers the path if both path and directory provided',
+    expected_command: 'terraform show some/path/to/terraform/plan',
+    options: { directory: Faker::File.dir,
+               path: 'some/path/to/terraform/plan' }
+  }
+
   it_behaves_like 'a command with an argument', [terraform_command, :directory]
 
-  it_behaves_like 'a command without a binary supplied', [terraform_command, described_class, terraform_config_path]
+  it_behaves_like 'a command with an argument', [terraform_command, :path]
 
-  it_behaves_like 'a command with an option', [terraform_command, :module_depth, terraform_config_path]
+  it_behaves_like 'a command without a binary supplied', [terraform_command, described_class, terraform_config_path]
 
   it_behaves_like 'a command with a flag', [terraform_command, :no_color, terraform_config_path]
 

--- a/spec/ruby_terraform/commands/show_spec.rb
+++ b/spec/ruby_terraform/commands/show_spec.rb
@@ -23,6 +23,8 @@ describe RubyTerraform::Commands::Show do
                path: 'some/path/to/terraform/plan' }
   }
 
+  it_behaves_like 'a command that accepts global options', [terraform_command, terraform_config_path]
+
   it_behaves_like 'a command with an argument', [terraform_command, :directory]
 
   it_behaves_like 'a command with an argument', [terraform_command, :path]

--- a/spec/ruby_terraform/commands/validate_spec.rb
+++ b/spec/ruby_terraform/commands/validate_spec.rb
@@ -22,14 +22,6 @@ describe RubyTerraform::Commands::Validate do
 
   it_behaves_like 'a command without a binary supplied', [terraform_command, described_class, terraform_config_path]
 
-  it_behaves_like 'a command that accepts vars', [terraform_command, terraform_config_path]
-
-  it_behaves_like 'a command with a boolean option', [terraform_command, :check_variables, terraform_config_path]
-
-  it_behaves_like 'a command with an array option', [terraform_command, :var_files, terraform_config_path]
-
-  it_behaves_like 'a command with an option', [terraform_command, :state, terraform_config_path]
-
   it_behaves_like 'a command with a flag', [terraform_command, :json, terraform_config_path]
 
   it_behaves_like 'a command with a flag', [terraform_command, :no_color, terraform_config_path]

--- a/spec/ruby_terraform/commands/validate_spec.rb
+++ b/spec/ruby_terraform/commands/validate_spec.rb
@@ -22,13 +22,13 @@ describe RubyTerraform::Commands::Validate do
 
   it_behaves_like 'a command that accepts vars', [terraform_command, terraform_config_path]
 
-  it_behaves_like 'a command with an option', [terraform_command, :state, terraform_config_path]
-
-  it_behaves_like 'a command with a flag', [terraform_command, :no_color, terraform_config_path]
-
   it_behaves_like 'a command with a boolean option', [terraform_command, :check_variables, terraform_config_path]
 
   it_behaves_like 'a command with an array option', [terraform_command, :var_files, terraform_config_path]
 
+  it_behaves_like 'a command with an option', [terraform_command, :state, terraform_config_path]
+
   it_behaves_like 'a command with a flag', [terraform_command, :json, terraform_config_path]
+
+  it_behaves_like 'a command with a flag', [terraform_command, :no_color, terraform_config_path]
 end

--- a/spec/ruby_terraform/commands/validate_spec.rb
+++ b/spec/ruby_terraform/commands/validate_spec.rb
@@ -16,6 +16,8 @@ describe RubyTerraform::Commands::Validate do
   terraform_command = 'validate'
   terraform_config_path = Faker::File.dir
 
+  it_behaves_like 'a command that accepts global options', [terraform_command, terraform_config_path]
+
   it_behaves_like 'a command with an argument', [terraform_command, :directory]
 
   it_behaves_like 'a command without a binary supplied', [terraform_command, described_class, terraform_config_path]

--- a/spec/ruby_terraform/commands/workspace_spec.rb
+++ b/spec/ruby_terraform/commands/workspace_spec.rb
@@ -16,10 +16,6 @@ describe RubyTerraform::Commands::Workspace do
   terraform_command = 'workspace list'
   terraform_config_path = Faker::File.dir
 
-  it_behaves_like 'a command with an argument', [terraform_command, :directory]
-
-  it_behaves_like 'a command without a binary supplied', [terraform_command, described_class, terraform_config_path]
-
   it_behaves_like 'a valid command line', {
     options: nil,
     reason: 'should default to list operation when no operation provided',
@@ -49,4 +45,8 @@ describe RubyTerraform::Commands::Workspace do
     reason: 'should delete the specified workspace',
     expected_command: 'terraform workspace delete staging'
   }
+
+  it_behaves_like 'a command with an argument', [terraform_command, :directory]
+
+  it_behaves_like 'a command without a binary supplied', [terraform_command, described_class, terraform_config_path]
 end

--- a/spec/ruby_terraform/commands/workspace_spec.rb
+++ b/spec/ruby_terraform/commands/workspace_spec.rb
@@ -46,6 +46,8 @@ describe RubyTerraform::Commands::Workspace do
     expected_command: 'terraform workspace delete staging'
   }
 
+  it_behaves_like 'a command that accepts global options', [terraform_command, terraform_config_path]
+
   it_behaves_like 'a command with an argument', [terraform_command, :directory]
 
   it_behaves_like 'a command without a binary supplied', [terraform_command, described_class, terraform_config_path]

--- a/spec/support/shared/a_command_that_accepts_global_options.rb
+++ b/spec/support/shared/a_command_that_accepts_global_options.rb
@@ -1,0 +1,7 @@
+require_relative '../../../lib/ruby_terraform/command_line/options'
+
+shared_examples 'a command that accepts global options' do |command, directory = nil|
+  RubyTerraform::CommandLine::Options.global_options.each do |option|
+    it_behaves_like 'a command with an option', [command, option, directory]
+  end
+end

--- a/spec/support/shared/a_command_with_an_array_option.rb
+++ b/spec/support/shared/a_command_with_an_array_option.rb
@@ -15,7 +15,7 @@ shared_examples 'a command with an array option' do |command, option, directory 
 
   it_behaves_like 'a valid command line', {
     reason: "ensures that #{singular} and #{option} options work together",
-    expected_command: "terraform #{command} #{switch}=option-value #{switch}=option-value1 #{switch}=option-value2#{argument}",
+    expected_command: "terraform #{command} #{switch}=option-value1 #{switch}=option-value2 #{switch}=option-value#{argument}",
     options: { directory: directory,
                single_option => 'option-value',
                option => %w[option-value1 option-value2] }

--- a/spec/support/shared/a_command_with_an_option.rb
+++ b/spec/support/shared/a_command_with_an_option.rb
@@ -4,9 +4,9 @@ shared_examples 'a command with an option' do |command, option, directory = nil,
 
   it_behaves_like 'a valid command line', {
     reason: "adds a #{switch} option if a #{option} is provided",
-    expected_command: "terraform #{command} #{switch}=true#{argument}",
+    expected_command: "terraform #{command} #{switch}=option-value#{argument}",
     options: { directory: directory,
-               option => 'true' }
+               option => 'option-value' }
   }
 
   it_behaves_like 'a valid command line', {

--- a/spec/support/shared/a_command_with_an_option.rb
+++ b/spec/support/shared/a_command_with_an_option.rb
@@ -8,4 +8,10 @@ shared_examples 'a command with an option' do |command, option, directory = nil,
     options: { directory: directory,
                option => 'true' }
   }
+
+  it_behaves_like 'a valid command line', {
+    reason: "does not add a #{switch} option if a #{option} is not provided",
+    expected_command: "terraform #{command}#{argument}",
+    options: { directory: directory }
+  }
 end

--- a/spec/support/shared/an_option_that_converts_its_value_to_boolean.rb
+++ b/spec/support/shared/an_option_that_converts_its_value_to_boolean.rb
@@ -1,0 +1,41 @@
+shared_examples 'an option that converts its value to a boolean' do
+  context 'when the value is nil' do
+    let(:value) { nil }
+
+    it 'sets the option value to nil' do
+      expect(command_line_option.instance_variable_get(:@value)).to be_nil
+    end
+  end
+
+  context 'when the value is true' do
+    let(:value) { true }
+
+    it 'sets the option value to true' do
+      expect(command_line_option.instance_variable_get(:@value)).to be_truthy
+    end
+  end
+
+  context "when the value is 'true'" do
+    let(:value) { 'true' }
+
+    it 'sets the option value to true' do
+      expect(command_line_option.instance_variable_get(:@value)).to be_truthy
+    end
+  end
+
+  context 'when the value is false' do
+    let(:value) { false }
+
+    it 'sets the option value to false' do
+      expect(command_line_option.instance_variable_get(:@value)).to be_falsey
+    end
+  end
+
+  context 'when the value is not true/false or a string starting with T' do
+    let(:value) { 'unknown' }
+
+    it 'sets the option value to false' do
+      expect(command_line_option.instance_variable_get(:@value)).to be_falsey
+    end
+  end
+end

--- a/spec/support/shared/an_option_that_derives_the_command_switch.rb
+++ b/spec/support/shared/an_option_that_derives_the_command_switch.rb
@@ -1,0 +1,15 @@
+shared_examples 'an option that derives the command switch' do
+  context 'when no switch override is supplied' do
+    it 'converts the supplied option key to kebab case to use as the switch' do
+      expect(command_line_option.instance_variable_get(:@switch)).to eq('-snake-key')
+    end
+  end
+
+  context 'when a switch override is supplied' do
+    let(:options) { { switch_override: '-different-switch' } }
+
+    it 'uses the switch override as the switch' do
+      expect(command_line_option.instance_variable_get(:@switch)).to eq('-different-switch')
+    end
+  end
+end

--- a/spec/support/shared/import_class_shared_examples.rb
+++ b/spec/support/shared/import_class_shared_examples.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-shared_examples 'an import command with an option' do |option|
-  switch = "-#{option.keys[0].to_s.sub('_', '-')}"
+shared_examples 'an import command with an option' do |opt_key|
+  switch = "-#{opt_key.to_s.sub('_', '-')}"
   common_options = {
     directory: Faker::File.dir,
     address: Faker::Lorem.word,
@@ -9,9 +9,15 @@ shared_examples 'an import command with an option' do |option|
   }.freeze
 
   it_behaves_like 'a valid command line', {
-    reason: "adds a #{switch} option if a #{option} is provided",
-    expected_command: "terraform import -config=#{common_options[:directory]} #{switch}=#{option.values[0]} #{common_options[:address]} #{common_options[:id]}",
-    options: common_options.merge(option)
+    reason: "adds a #{switch} option if a #{opt_key} is provided",
+    expected_command: "terraform import -config=#{common_options[:directory]} #{switch}=option-value #{common_options[:address]} #{common_options[:id]}",
+    options: common_options.merge({ opt_key => 'option-value' })
+  }
+
+  it_behaves_like 'a valid command line', {
+    reason: "does not add a #{switch} option if a #{opt_key} is not provided",
+    expected_command: "terraform import -config=#{common_options[:directory]} #{common_options[:address]} #{common_options[:id]}",
+    options: common_options
   }
 end
 

--- a/spec/support/shared/import_class_shared_examples.rb
+++ b/spec/support/shared/import_class_shared_examples.rb
@@ -62,3 +62,9 @@ shared_examples 'an import command with a boolean option' do |opt_key|
     options: common_options.merge({ opt_key => false })
   }
 end
+
+shared_examples 'an import command that accepts global options' do
+  RubyTerraform::CommandLine::Options.global_options.each do |opt_key|
+    it_behaves_like 'an import command with an option', opt_key
+  end
+end

--- a/spec/support/shared/import_class_shared_examples.rb
+++ b/spec/support/shared/import_class_shared_examples.rb
@@ -58,7 +58,7 @@ shared_examples 'an import command with a boolean option' do |opt_key|
 
   it_behaves_like 'a valid command line', {
     reason: "does not include #{switch}=false when the #{opt_key} option is false",
-    expected_command: "terraform import -config=#{common_options[:directory]} #{common_options[:address]} #{common_options[:id]}",
+    expected_command: "terraform import -config=#{common_options[:directory]} #{switch}=false #{common_options[:address]} #{common_options[:id]}",
     options: common_options.merge({ opt_key => false })
   }
 end

--- a/spec/support/shared/import_class_shared_examples.rb
+++ b/spec/support/shared/import_class_shared_examples.rb
@@ -57,7 +57,7 @@ shared_examples 'an import command with a boolean option' do |opt_key|
   }
 
   it_behaves_like 'a valid command line', {
-    reason: "does not include #{switch}=false when the #{opt_key} option is false",
+    reason: "includes #{switch}=false when the #{opt_key} option is false",
     expected_command: "terraform import -config=#{common_options[:directory]} #{switch}=false #{common_options[:address]} #{common_options[:id]}",
     options: common_options.merge({ opt_key => false })
   }


### PR DESCRIPTION
This one's **definitely** not in a state for merging (rspec is happy with it - but there's no doco and there's still a few areas I'd like to change) - just figured before I spend too much more time on it I'd see if you're likely to see it as a path forward or not?  

Basically it 
- moves the Lino command line builder responsibility out of Base and into its own class
- moves the "should this command line switch/option be included in the command line” logic out of the various Command classes and into Option specific classes
- simplifies the command classes down to being the repository for what commands, arguments and options they accept.

Let me know if you think its worth continuing with (happy to move the global options and Terraform 0.15 parameter stuff into a separate PR as well to keep things smaller)