### PR TITLE
Refactor commands to be configuration driven and move lino logic into a builder.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,10 @@ Layout/LineLength:
     - spec/**/*.rb
     - ./*.gemspec
 
+Metrics/ModuleLength:
+  Exclude:
+    - spec/**/*.rb
+
 Metrics/BlockLength:
   IgnoredMethods:
     - describe

--- a/lib/ruby_terraform/command_line/builder.rb
+++ b/lib/ruby_terraform/command_line/builder.rb
@@ -1,0 +1,55 @@
+require 'lino'
+
+module RubyTerraform
+  module CommandLine
+    class Builder
+      def initialize(binary:, sub_commands:, options:, arguments:)
+        @builder = instantiate_builder(binary)
+        @sub_commands = array_of(sub_commands)
+        @options = array_of(options)
+        @arguments = array_of(arguments)
+      end
+
+      def build
+        configure_builder
+        builder.build
+      end
+
+      private
+
+      attr_reader :builder, :sub_commands, :options, :arguments
+
+      def configure_builder
+        add_subcommands_and_options
+        add_arguments
+      end
+
+      def add_subcommands_and_options
+        sub_commands[0...-1].each do |command|
+          @builder = builder.with_subcommand(command)
+        end
+        @builder = builder.with_subcommand(sub_commands.last) do |sub|
+          options.inject(sub) do |sub_command, option|
+            option.add_to_subcommand(sub_command)
+          end
+        end
+      end
+
+      def add_arguments
+        @builder = builder.with_arguments(arguments)
+      end
+
+      def instantiate_builder(binary)
+        Lino::CommandLineBuilder
+          .for_command(binary)
+          .with_option_separator('=')
+      end
+
+      def array_of(value)
+        return value if value.respond_to?(:each)
+
+        value.nil? ? [] : [value]
+      end
+    end
+  end
+end

--- a/lib/ruby_terraform/command_line/option/base.rb
+++ b/lib/ruby_terraform/command_line/option/base.rb
@@ -1,0 +1,24 @@
+module RubyTerraform
+  module CommandLine
+    module Option
+      class Base
+        def initialize(switch, value)
+          @switch = switch
+          coerce_value(value)
+        end
+
+        def add_to_subcommand(_sub)
+          raise 'not implemented'
+        end
+
+        private
+
+        attr_reader :switch, :value
+
+        def coerce_value(value)
+          @value = value
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_terraform/command_line/option/boolean.rb
+++ b/lib/ruby_terraform/command_line/option/boolean.rb
@@ -1,0 +1,16 @@
+require_relative 'boolean_value'
+require_relative 'base'
+
+module RubyTerraform
+  module CommandLine
+    module Option
+      class Boolean < Base
+        include BooleanValue
+
+        def add_to_subcommand(sub)
+          sub.with_option(switch, value)
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_terraform/command_line/option/boolean_value.rb
+++ b/lib/ruby_terraform/command_line/option/boolean_value.rb
@@ -1,0 +1,29 @@
+module RubyTerraform
+  module CommandLine
+    module Option
+      module BooleanValue
+        def coerce_value(value)
+          @value = boolean_val(value)
+        end
+
+        private
+
+        def boolean_val(value)
+          return nil if value.nil?
+          return value if a_boolean?(value)
+          return true if true_as_string?(value)
+
+          false
+        end
+
+        def a_boolean?(value)
+          value.is_a?(TrueClass) || value.is_a?(FalseClass)
+        end
+
+        def true_as_string?(value)
+          value.respond_to?(:downcase) && value.downcase == 'true'
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_terraform/command_line/option/flag.rb
+++ b/lib/ruby_terraform/command_line/option/flag.rb
@@ -1,0 +1,16 @@
+require_relative 'boolean_value'
+require_relative 'base'
+
+module RubyTerraform
+  module CommandLine
+    module Option
+      class Flag < Base
+        include BooleanValue
+
+        def add_to_subcommand(sub)
+          value ? sub.with_flag(switch) : sub
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_terraform/command_line/option/standard.rb
+++ b/lib/ruby_terraform/command_line/option/standard.rb
@@ -1,0 +1,40 @@
+require 'json'
+require_relative 'base'
+
+module RubyTerraform
+  module CommandLine
+    module Option
+      class Standard < Base
+        def add_to_subcommand(sub)
+          if value.respond_to?(:keys)
+            add_hash_to_subcommand(sub)
+          elsif value.respond_to?(:each)
+            add_array_to_subcommand(sub)
+          else
+            sub.with_option(switch, value)
+          end
+        end
+
+        private
+
+        def add_hash_to_subcommand(sub)
+          sub.with_repeated_option(
+            switch,
+            value.map do |hash_key, hash_value|
+              "'#{hash_key}=#{as_string(hash_value)}'"
+            end,
+            separator: ' '
+          )
+        end
+
+        def add_array_to_subcommand(sub)
+          sub.with_repeated_option(switch, value)
+        end
+
+        def as_string(value)
+          value.is_a?(String) ? value : JSON.generate(value)
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_terraform/command_line/option/switch.rb
+++ b/lib/ruby_terraform/command_line/option/switch.rb
@@ -1,0 +1,43 @@
+module RubyTerraform
+  module CommandLine
+    module Option
+      class Switch
+        def initialize(switch)
+          @switch_without_prefix = switch[0] == '-' ? switch[1..] : switch
+        end
+
+        def to_s
+          "-#{switch_without_prefix}"
+        end
+
+        def as_key
+          snake_case.to_sym
+        end
+
+        def as_plural_key
+          "#{snake_case}s".to_sym
+        end
+
+        def ==(other)
+          to_s == other
+        end
+
+        def eql?(other)
+          to_s == other
+        end
+
+        def hash
+          to_s.hash
+        end
+
+        private
+
+        attr_reader :switch_without_prefix
+
+        def snake_case
+          switch_without_prefix.gsub('-', '_')
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_terraform/command_line/options_factory.rb
+++ b/lib/ruby_terraform/command_line/options_factory.rb
@@ -1,0 +1,79 @@
+require_relative 'option/standard'
+require_relative 'option/flag'
+require_relative 'option/boolean'
+require_relative 'option/switch'
+
+module RubyTerraform
+  module CommandLine
+    class OptionsFactory
+      PLURAL_SWITCHES = Set.new(
+        %w[-var -target -var-file]
+      ).freeze
+      BOOLEAN_SWITCHES = Set.new(
+        %w[-auto-approve -backend -get -get-plugins -input -list -lock
+           -refresh -upgrade -verify-plugins -write]
+      ).freeze
+      FLAG_SWITCHES = Set.new(
+        %w[-allow-missing -allow-missing-config -check -compact-warnings
+           -destroy -detailed-exitcode -diff -draw-cycles -force -force-copy
+           -ignore-remote-version -json -no-color -raw -reconfigure -recursive
+           -update]
+      ).freeze
+      OVERRIDE_SWITCHES = {
+        config: :directory,
+        out: :plan
+      }.freeze
+
+      def self.from(values, switches)
+        new(values, switches).from
+      end
+
+      private_class_method :new
+
+      def initialize(values, switches)
+        @switches = switches.map { |switch| Option::Switch.new(switch) }
+        @values = values
+      end
+
+      def from
+        switches.each_with_object([]) do |switch, options|
+          options.append(*options_from_switch(switch))
+        end
+      end
+
+      private
+
+      attr_reader :switches, :values
+
+      def options_from_switch(switch)
+        return plural_options(switch) if PLURAL_SWITCHES.include?(switch)
+        return boolean_option(switch) if BOOLEAN_SWITCHES.include?(switch)
+        return flag_option(switch) if FLAG_SWITCHES.include?(switch)
+        return override_option(switch) if OVERRIDE_SWITCHES.key?(switch.as_key)
+
+        standard_option(switch, switch.as_key)
+      end
+
+      def boolean_option(switch)
+        [Option::Boolean.new(switch.to_s, values[switch.as_key])]
+      end
+
+      def flag_option(switch)
+        [Option::Flag.new(switch.to_s, values[switch.as_key])]
+      end
+
+      def standard_option(switch, hash_key)
+        [Option::Standard.new(switch.to_s, values[hash_key])]
+      end
+
+      def override_option(switch)
+        standard_option(switch, OVERRIDE_SWITCHES[switch.as_key])
+      end
+
+      def plural_options(switch)
+        standard_option(switch.to_s, switch.as_key) +
+          standard_option(switch.to_s, switch.as_plural_key)
+      end
+    end
+  end
+end

--- a/lib/ruby_terraform/commands/apply.rb
+++ b/lib/ruby_terraform/commands/apply.rb
@@ -1,49 +1,27 @@
-require 'json'
 require_relative 'base'
 
 module RubyTerraform
   module Commands
     class Apply < Base
-      def configure_command(builder, opts)
-        directory = opts[:directory]
-        plan = opts[:plan]
-        vars = opts[:vars] || {}
-        var_file = opts[:var_file]
-        var_files = opts[:var_files] || []
-        target = opts[:target]
-        targets = opts[:targets] || []
-        state = opts[:state]
-        input = opts[:input]
-        auto_approve = opts[:auto_approve]
-        no_backup = opts[:no_backup]
-        backup = no_backup ? '-' : opts[:backup]
-        no_color = opts[:no_color]
+      def sub_commands(_values)
+        'apply'
+      end
 
-        builder
-          .with_subcommand('apply') do |sub|
-          vars.each do |key, value|
-            var_value = value.is_a?(String) ? value : JSON.generate(value)
-            sub = sub.with_option(
-              '-var', "'#{key}=#{var_value}'", separator: ' '
-            )
-          end
-          sub = sub.with_option('-var-file', var_file) if var_file
-          var_files.each do |file|
-            sub = sub.with_option('-var-file', file)
-          end
-          sub = sub.with_option('-target', target) if target
-          targets.each do |file|
-            sub = sub.with_option('-target', file)
-          end
-          sub = sub.with_option('-state', state) if state
-          sub = sub.with_option('-input', input) if input
-          sub = sub.with_option('-auto-approve', auto_approve) unless
-              auto_approve.nil?
-          sub = sub.with_option('-backup', backup) if backup
-          sub = sub.with_flag('-no-color') if no_color
-          sub
-        end
-          .with_argument(plan || directory)
+      def switches
+        %w[-backup -lock -lock-timeout -input -auto-approve -no-color -state
+           -target -var -var-file]
+      end
+
+      def arguments(values)
+        values[:plan] || values[:directory]
+      end
+
+      def option_default_values(_opts)
+        { vars: {}, var_files: [], targets: [] }
+      end
+
+      def option_override_values(opts)
+        { backup: opts[:no_backup] ? '-' : opts[:backup] }
       end
     end
   end

--- a/lib/ruby_terraform/commands/base.rb
+++ b/lib/ruby_terraform/commands/base.rb
@@ -1,5 +1,6 @@
-require 'lino'
 require_relative '../errors'
+require_relative '../command_line/builder'
+require_relative '../command_line/options_factory'
 
 module RubyTerraform
   module Commands
@@ -12,20 +13,12 @@ module RubyTerraform
         @stdin = stdin || RubyTerraform.configuration.stdin
         @stdout = stdout || RubyTerraform.configuration.stdout
         @stderr = stderr || RubyTerraform.configuration.stderr
+        initialize_command
       end
 
       def execute(opts = {})
-        builder = instantiate_builder
-
         do_before(opts)
-        command = configure_command(builder, opts).build
-        logger.debug("Running '#{command}'.")
-
-        command.execute(
-          stdin: stdin,
-          stdout: stdout,
-          stderr: stderr
-        )
+        build_and_execute_command(opts)
         do_after(opts)
       rescue Open4::SpawnError
         message = "Failed while running '#{command_name}'."
@@ -37,21 +30,66 @@ module RubyTerraform
 
       attr_reader :binary, :logger, :stdin, :stdout, :stderr
 
+      def build_and_execute_command(opts)
+        command = build_command(opts)
+        logger.debug("Running '#{command}'.")
+        command.execute(
+          stdin: stdin,
+          stdout: stdout,
+          stderr: stderr
+        )
+      end
+
       def command_name
         self.class.to_s.split('::')[-1].downcase
       end
 
-      def instantiate_builder
-        Lino::CommandLineBuilder
-          .for_command(binary)
-          .with_option_separator('=')
+      def do_before(_opts); end
+
+      def do_after(_opts); end
+
+      private
+
+      def initialize_command; end
+
+      def build_command(opts)
+        values = apply_option_defaults_and_overrides(opts)
+        RubyTerraform::CommandLine::Builder.new(
+          binary: @binary,
+          sub_commands: sub_commands(values),
+          options: options(values),
+          arguments: arguments(values)
+        ).build
       end
 
-      def do_before(opts); end
+      def apply_option_defaults_and_overrides(opts)
+        option_default_values(opts).merge(opts)
+                                   .merge(option_override_values(opts))
+      end
 
-      def configure_command(builder, opts); end
+      def option_default_values(_values)
+        {}
+      end
 
-      def do_after(opts); end
+      def option_override_values(_values)
+        {}
+      end
+
+      def sub_commands(_values)
+        []
+      end
+
+      def options(values)
+        RubyTerraform::CommandLine::OptionsFactory.from(values, switches)
+      end
+
+      def switches
+        []
+      end
+
+      def arguments(_values)
+        []
+      end
     end
   end
 end

--- a/lib/ruby_terraform/commands/destroy.rb
+++ b/lib/ruby_terraform/commands/destroy.rb
@@ -3,45 +3,24 @@ require_relative 'base'
 module RubyTerraform
   module Commands
     class Destroy < Base
-      def configure_command(builder, opts)
-        directory = opts[:directory]
-        vars = opts[:vars] || {}
-        var_file = opts[:var_file]
-        var_files = opts[:var_files] || []
-        target = opts[:target]
-        targets = opts[:targets] || []
-        state = opts[:state]
-        force = opts[:force]
-        no_backup = opts[:no_backup]
-        backup = no_backup ? '-' : opts[:backup]
-        no_color = opts[:no_color]
-        auto_approve = opts[:auto_approve]
+      def switches
+        %w[-backup -auto-approve -force -no-color -state -target -var -var-file]
+      end
 
-        builder
-          .with_subcommand('destroy') do |sub|
-          vars.each do |key, value|
-            var_value = value.is_a?(String) ? value : JSON.generate(value)
-            sub = sub.with_option(
-              '-var', "'#{key}=#{var_value}'", separator: ' '
-            )
-          end
-          sub = sub.with_option('-var-file', var_file) if var_file
-          var_files.each do |file|
-            sub = sub.with_option('-var-file', file)
-          end
-          sub = sub.with_option('-target', target) if target
-          targets.each do |target_name|
-            sub = sub.with_option('-target', target_name)
-          end
-          sub = sub.with_option('-state', state) if state
-          sub = sub.with_option('-auto-approve', auto_approve) unless
-              auto_approve.nil?
-          sub = sub.with_option('-backup', backup) if backup
-          sub = sub.with_flag('-no-color') if no_color
-          sub = sub.with_flag('-force') if force
-          sub
-        end
-          .with_argument(directory)
+      def sub_commands(_values)
+        'destroy'
+      end
+
+      def arguments(values)
+        values[:directory]
+      end
+
+      def option_default_values(_opts)
+        { vars: {}, var_files: [], targets: [] }
+      end
+
+      def option_override_values(opts)
+        { backup: opts[:no_backup] ? '-' : opts[:backup] }
       end
     end
   end

--- a/lib/ruby_terraform/commands/format.rb
+++ b/lib/ruby_terraform/commands/format.rb
@@ -1,29 +1,18 @@
-# frozen_string_literal: true
-
 require_relative 'base'
 
 module RubyTerraform
   module Commands
     class Format < Base
-      def configure_command(builder, opts)
-        directory = opts[:directory]
-        check = opts[:check]
-        diff = opts[:diff]
-        list = opts[:list]
-        no_color = opts[:no_color]
-        recursive = opts[:recursive]
-        write = opts[:write]
+      def switches
+        %w[-list -write -diff -check -recursive -no-color]
+      end
 
-        builder.with_subcommand('fmt') do |sub|
-          sub = sub.with_option('-list', list) if list
-          sub = sub.with_option('-write', write) if write
+      def sub_commands(_values)
+        'fmt'
+      end
 
-          sub = sub.with_flag('-check') if check
-          sub = sub.with_flag('-diff') if diff
-          sub = sub.with_flag('-no-color') if no_color
-          sub = sub.with_flag('-recursive') if recursive
-          sub
-        end.with_argument(directory)
+      def arguments(values)
+        values[:directory]
       end
     end
   end

--- a/lib/ruby_terraform/commands/get.rb
+++ b/lib/ruby_terraform/commands/get.rb
@@ -3,14 +3,16 @@ require_relative 'base'
 module RubyTerraform
   module Commands
     class Get < Base
-      def configure_command(builder, opts)
-        builder
-          .with_subcommand('get') do |sub|
-          sub = sub.with_option('-update', true) if opts[:update]
-          sub = sub.with_flag('-no-color') if opts[:no_color]
-          sub
-        end
-          .with_argument(opts[:directory])
+      def switches
+        %w[-update -no-color]
+      end
+
+      def sub_commands(_values)
+        'get'
+      end
+
+      def arguments(values)
+        values[:directory]
       end
     end
   end

--- a/lib/ruby_terraform/commands/import.rb
+++ b/lib/ruby_terraform/commands/import.rb
@@ -1,45 +1,26 @@
-# frozen_string_literal: true
-
-require 'json'
 require_relative 'base'
 
 module RubyTerraform
   module Commands
     class Import < Base
-      def configure_command(builder, opts)
-        directory = opts[:directory]
-        vars = opts[:vars] || {}
-        var_file = opts[:var_file]
-        var_files = opts[:var_files] || []
-        no_color = opts[:no_color]
-        no_backup = opts[:no_backup]
-        backup = no_backup ? '-' : opts[:backup]
-        state = opts[:state]
-        input = opts[:input]
-        address = opts[:address]
-        id = opts[:id]
+      def switches
+        %w[-config -backup -input -no-color -state -var -var-file]
+      end
 
-        builder
-          .with_subcommand('import') do |sub|
-            sub = sub.with_option('-config', directory)
-            vars.each do |key, value|
-              var_value = value.is_a?(String) ? value : JSON.generate(value)
-              sub = sub.with_option(
-                '-var', "'#{key}=#{var_value}'", separator: ' '
-              )
-            end
-            sub = sub.with_option('-var-file', var_file) if var_file
-            var_files.each do |file|
-              sub = sub.with_option('-var-file', file)
-            end
-            sub = sub.with_option('-state', state) if state
-            sub = sub.with_option('-input', input) if input
-            sub = sub.with_option('-backup', backup) if backup
-            sub = sub.with_flag('-no-color') if no_color
-            sub
-          end
-          .with_argument(address)
-          .with_argument(id)
+      def sub_commands(_values)
+        'import'
+      end
+
+      def arguments(values)
+        [values[:address], values[:id]]
+      end
+
+      def option_default_values(_opts)
+        { vars: {}, var_files: [] }
+      end
+
+      def option_override_values(opts)
+        { backup: opts[:no_backup] ? '-' : opts[:backup] }
       end
     end
   end

--- a/lib/ruby_terraform/commands/init.rb
+++ b/lib/ruby_terraform/commands/init.rb
@@ -3,43 +3,21 @@ require_relative 'base'
 module RubyTerraform
   module Commands
     class Init < Base
-      def configure_command(builder, opts)
-        no_color = opts[:no_color]
-        backend = opts[:backend]
-        get = opts[:get]
-        backend_config = opts[:backend_config] || {}
-        source = opts[:from_module]
-        path = opts[:path]
-        plugin_dir = opts[:plugin_dir]
-        force_copy = opts[:force_copy]
+      def switches
+        %w[-backend -backend-config -from-module -get -no-color -plugin-dir
+           -force-copy]
+      end
 
-        builder = builder
-                  .with_subcommand('init') do |sub|
-          sub = sub.with_option('-backend', backend) unless backend.nil?
-          unless force_copy.nil?
-            sub = sub.with_option('-force-copy',
-                                  force_copy)
-          end
-          sub = sub.with_option('-get', get) unless get.nil?
-          sub = sub.with_option('-from-module', source) if source
-          sub = sub.with_flag('-no-color') if no_color
-          unless plugin_dir.nil?
-            sub = sub.with_option('-plugin-dir',
-                                  plugin_dir)
-          end
-          backend_config.each do |key, value|
-            sub = sub.with_option(
-              '-backend-config',
-              "'#{key}=#{value}'",
-              separator: ' '
-            )
-          end
-          sub
-        end
+      def sub_commands(_values)
+        'init'
+      end
 
-        builder = builder.with_argument(path) if path
+      def arguments(values)
+        values[:path]
+      end
 
-        builder
+      def option_default_values(_opts)
+        { backend_config: {} }
       end
     end
   end

--- a/lib/ruby_terraform/commands/output.rb
+++ b/lib/ruby_terraform/commands/output.rb
@@ -4,29 +4,22 @@ require_relative 'base'
 module RubyTerraform
   module Commands
     class Output < Base
-      def initialize(**kwargs)
-        super(**kwargs)
-        @stdout = StringIO.new unless
-            defined?(@stdout) && @stdout.respond_to?(:string)
+      def initialize_command
+        return if defined?(@stdout) && @stdout.respond_to?(:string)
+
+        @stdout = StringIO.new
       end
 
-      def configure_command(builder, opts)
-        name = opts[:name]
-        state = opts[:state]
-        no_color = opts[:no_color]
-        json = opts[:json]
-        mod = opts[:module]
+      def switches
+        %w[-json -raw -no-color -state -module]
+      end
 
-        builder = builder
-                  .with_subcommand('output') do |sub|
-          sub = sub.with_flag('-no-color') if no_color
-          sub = sub.with_flag('-json') if json
-          sub = sub.with_option('-state', state) if state
-          sub = sub.with_option('-module', mod) if mod
-          sub
-        end
-        builder = builder.with_argument(name) if name
-        builder
+      def sub_commands(_values)
+        'output'
+      end
+
+      def arguments(values)
+        values[:name]
       end
 
       def do_after(opts)

--- a/lib/ruby_terraform/commands/plan.rb
+++ b/lib/ruby_terraform/commands/plan.rb
@@ -1,46 +1,22 @@
-require 'json'
 require_relative 'base'
 
 module RubyTerraform
   module Commands
     class Plan < Base
-      def configure_command(builder, opts)
-        directory = opts[:directory]
-        vars = opts[:vars] || {}
-        var_file = opts[:var_file]
-        var_files = opts[:var_files] || []
-        target = opts[:target]
-        targets = opts[:targets] || []
-        state = opts[:state]
-        plan = opts[:plan]
-        input = opts[:input]
-        destroy = opts[:destroy]
-        no_color = opts[:no_color]
+      def switches
+        %w[-destroy -input -no-color -out -state -target -var -var-file]
+      end
 
-        builder
-          .with_subcommand('plan') do |sub|
-          vars.each do |key, value|
-            var_value = value.is_a?(String) ? value : JSON.generate(value)
-            sub = sub.with_option(
-              '-var', "'#{key}=#{var_value}'", separator: ' '
-            )
-          end
-          sub = sub.with_option('-var-file', var_file) if var_file
-          var_files.each do |file|
-            sub = sub.with_option('-var-file', file)
-          end
-          sub = sub.with_option('-target', target) if target
-          targets.each do |file|
-            sub = sub.with_option('-target', file)
-          end
-          sub = sub.with_option('-state', state) if state
-          sub = sub.with_option('-out', plan) if plan
-          sub = sub.with_option('-input', input) if input
-          sub = sub.with_flag('-destroy') if destroy
-          sub = sub.with_flag('-no-color') if no_color
-          sub
-        end
-          .with_argument(directory)
+      def sub_commands(_values)
+        'plan'
+      end
+
+      def option_default_values(_opts)
+        { vars: {}, var_files: [], targets: [] }
+      end
+
+      def arguments(values)
+        values[:directory]
       end
     end
   end

--- a/lib/ruby_terraform/commands/refresh.rb
+++ b/lib/ruby_terraform/commands/refresh.rb
@@ -1,42 +1,22 @@
-require 'json'
 require_relative 'base'
 
 module RubyTerraform
   module Commands
     class Refresh < Base
-      def configure_command(builder, opts)
-        directory = opts[:directory]
-        vars = opts[:vars] || {}
-        var_file = opts[:var_file]
-        var_files = opts[:var_files] || []
-        state = opts[:state]
-        input = opts[:input]
-        target = opts[:target]
-        targets = opts[:targets] || []
-        no_color = opts[:no_color]
+      def switches
+        %w[-input -no-color -state -target -var -var-file] + super
+      end
 
-        builder
-          .with_subcommand('refresh') do |sub|
-          vars.each do |key, value|
-            var_value = value.is_a?(String) ? value : JSON.generate(value)
-            sub = sub.with_option(
-              '-var', "'#{key}=#{var_value}'", separator: ' '
-            )
-          end
-          sub = sub.with_option('-var-file', var_file) if var_file
-          var_files.each do |file|
-            sub = sub.with_option('-var-file', file)
-          end
-          sub = sub.with_option('-state', state) if state
-          sub = sub.with_option('-input', input) if input
-          sub = sub.with_option('-target', target) if target
-          targets.each do |target_name|
-            sub = sub.with_option('-target', target_name)
-          end
-          sub = sub.with_flag('-no-color') if no_color
-          sub
-        end
-          .with_argument(directory)
+      def sub_commands(_values)
+        'refresh'
+      end
+
+      def arguments(values)
+        values[:directory]
+      end
+
+      def option_default_values(_opts)
+        { vars: {}, var_files: [], targets: [] }
       end
     end
   end

--- a/lib/ruby_terraform/commands/remote_config.rb
+++ b/lib/ruby_terraform/commands/remote_config.rb
@@ -3,24 +3,16 @@ require_relative 'base'
 module RubyTerraform
   module Commands
     class RemoteConfig < Base
-      def configure_command(builder, opts)
-        backend = opts[:backend]
-        no_color = opts[:no_color]
-        backend_config = opts[:backend_config] || {}
+      def switches
+        %w[-backend -backend-config -no-color]
+      end
 
-        builder
-          .with_subcommand('remote')
-          .with_subcommand('config') do |sub|
-          sub = sub.with_option('-backend', backend) if backend
-          backend_config.each do |key, value|
-            sub = sub.with_option(
-              '-backend-config', "'#{key}=#{value}'", separator: ' '
-            )
-          end
+      def sub_commands(_values)
+        %w[remote config]
+      end
 
-          sub = sub.with_flag('-no-color') if no_color
-          sub
-        end
+      def option_default_values(_opts)
+        { backend_config: {} }
       end
     end
   end

--- a/lib/ruby_terraform/commands/show.rb
+++ b/lib/ruby_terraform/commands/show.rb
@@ -1,24 +1,18 @@
-# frozen_string_literal: true
-
 require_relative 'base'
 
 module RubyTerraform
   module Commands
     class Show < Base
-      def configure_command(builder, opts)
-        path = opts[:path] || opts[:directory]
-        json_format = opts[:json]
-        no_color = opts[:no_color]
-        module_depth = opts[:module_depth]
+      def switches
+        %w[-json -no-color -module-depth] + super
+      end
 
-        builder
-          .with_subcommand('show') do |sub|
-          sub = sub.with_option('-module-depth', module_depth) if module_depth
-          sub = sub.with_flag('-no-color') if no_color
-          sub = sub.with_flag('-json') if json_format
-          sub
-        end
-          .with_argument(path)
+      def sub_commands(_values)
+        'show'
+      end
+
+      def arguments(values)
+        values[:path] || values[:directory]
       end
     end
   end

--- a/lib/ruby_terraform/commands/validate.rb
+++ b/lib/ruby_terraform/commands/validate.rb
@@ -1,39 +1,22 @@
-require 'json'
 require_relative 'base'
 
 module RubyTerraform
   module Commands
     class Validate < Base
-      def configure_command(builder, opts)
-        directory = opts[:directory]
-        vars = opts[:vars] || {}
-        var_file = opts[:var_file]
-        var_files = opts[:var_files] || []
-        state = opts[:state]
-        check_variables = opts[:check_variables]
-        no_color = opts[:no_color]
-        json_format = opts[:json]
+      def switches
+        %w[-json -no-color -var -var-file -state -check-variables] + super
+      end
 
-        builder
-          .with_subcommand('validate') do |sub|
-          vars.each do |key, value|
-            var_value = value.is_a?(String) ? value : JSON.generate(value)
-            sub = sub.with_option(
-              '-var', "'#{key}=#{var_value}'", separator: ' '
-            )
-          end
-          sub = sub.with_option('-var-file', var_file) if var_file
-          var_files.each do |file|
-            sub = sub.with_option('-var-file', file)
-          end
-          sub = sub.with_option('-state', state) if state
-          sub = sub.with_option('-check-variables', check_variables) unless
-              check_variables.nil?
-          sub = sub.with_flag('-no-color') if no_color
-          sub = sub.with_flag('-json') if json_format
-          sub
-        end
-          .with_argument(directory)
+      def sub_commands(_values)
+        'validate'
+      end
+
+      def arguments(values)
+        values[:directory]
+      end
+
+      def option_default_values(_opts)
+        { vars: {}, var_files: [] }
       end
     end
   end

--- a/lib/ruby_terraform/commands/workspace.rb
+++ b/lib/ruby_terraform/commands/workspace.rb
@@ -3,18 +3,21 @@ require_relative 'base'
 module RubyTerraform
   module Commands
     class Workspace < Base
-      def configure_command(builder, opts)
-        directory = opts[:directory] || nil
-        operation = opts[:operation] || 'list'
-        workspace = opts[:workspace] || nil
+      def sub_commands(values)
+        commands = ['workspace', values[:operation]]
+        if values[:workspace] && values[:operation] != 'list'
+          commands << values[:workspace]
+        else
+          commands
+        end
+      end
 
-        builder = builder
-                  .with_subcommand('workspace')
-                  .with_subcommand(operation)
+      def arguments(values)
+        values[:directory]
+      end
 
-        builder = builder.with_subcommand(workspace) if
-            workspace && operation != 'list'
-        builder.with_argument(directory)
+      def option_default_values(_opts)
+        { directory: nil, operation: 'list', workspace: nil }
       end
     end
   end

--- a/lib/ruby_terraform/output.rb
+++ b/lib/ruby_terraform/output.rb
@@ -1,20 +1,23 @@
 module RubyTerraform
   class Output
-    def self.for(opts)
-      name = opts[:name]
-      backend_config = opts[:backend_config]
+    class << self
+      def for(opts)
+        Dir.chdir(create_config_directory(opts)) do
+          RubyTerraform.init(backend_config: opts[:backend_config])
+          RubyTerraform.output(name: opts[:name])
+        end
+      end
 
-      source_directory = opts[:source_directory]
-      work_directory = opts[:work_directory]
+      private
 
-      configuration_directory = File.join(work_directory, source_directory)
+      def create_config_directory(opts)
+        source_directory = opts[:source_directory]
+        work_directory = opts[:work_directory]
 
-      FileUtils.mkdir_p File.dirname(configuration_directory)
-      FileUtils.cp_r source_directory, configuration_directory
-
-      Dir.chdir(configuration_directory) do
-        RubyTerraform.init(backend_config: backend_config)
-        RubyTerraform.output(name: name)
+        configuration_directory = File.join(work_directory, source_directory)
+        FileUtils.mkdir_p File.dirname(configuration_directory)
+        FileUtils.cp_r source_directory, configuration_directory
+        configuration_directory
       end
     end
   end

--- a/spec/ruby_terraform/command_line/builder_spec.rb
+++ b/spec/ruby_terraform/command_line/builder_spec.rb
@@ -1,0 +1,142 @@
+require 'spec_helper'
+require_relative '../../../lib/ruby_terraform/command_line/builder'
+require_relative '../../../lib/ruby_terraform/command_line/option/standard'
+
+module RubyTerraform
+  module CommandLine
+    describe Builder do
+      subject(:command_line_builder) { described_class.new(builder_options) }
+      let(:builder_options) do
+        {
+          binary: binary,
+          sub_commands: sub_commands,
+          options: options,
+          arguments: arguments
+        }
+      end
+      let(:binary) { 'terraform' }
+      let(:first_command) { 'remote' }
+      let(:last_command) { 'config' }
+      let(:sub_commands) { [first_command, last_command] }
+      let(:arguments) { '/argument/one' }
+      let(:options) { %w[-opt1 -opt2] }
+      let(:standard) do
+        instance_double(RubyTerraform::CommandLine::Option::Standard)
+      end
+      let(:built_command) { "#{binary} #{sub_commands} #{arguments}" }
+      let(:lino_builder) { instance_double(Lino::CommandLineBuilder) }
+      let(:lino_subcommand_builder) { instance_double(Lino::SubcommandBuilder) }
+
+      before do
+        allow(Lino::CommandLineBuilder).to receive(:for_command).and_return(lino_builder)
+        allow(lino_builder).to receive(:with_option_separator).and_return(lino_builder)
+        allow(lino_builder).to receive(:with_subcommand).with(first_command).and_return(lino_builder)
+        allow(lino_builder).to receive(:with_subcommand).with(last_command)
+                                                        .and_return(lino_builder)
+                                                        .and_yield(lino_subcommand_builder)
+        allow(lino_builder).to receive(:with_arguments).and_return(lino_builder)
+        allow(lino_builder).to receive(:build).and_return(built_command)
+        allow(options).to receive(:inject).and_yield(lino_subcommand_builder,
+                                                     standard)
+        allow(standard).to receive(:add_to_subcommand).and_return(lino_subcommand_builder)
+      end
+
+      shared_examples 'it ensures the instance variable is an array' do |instance_var|
+        before { command_line_builder }
+
+        context 'when the supplied parameter is an array' do
+          let(:param) { %w[test value] }
+
+          it 'assigns the value to the instance variable' do
+            expect(command_line_builder.instance_variable_get(instance_var)).to eq(param)
+          end
+        end
+
+        context 'when the supplied parameter is a string' do
+          let(:param) { 'test' }
+
+          it 'converts the value to an array and assigns it to the instance variable' do
+            expect(command_line_builder.instance_variable_get(instance_var)).to eq([param])
+          end
+        end
+
+        context 'when the supplied command is nil' do
+          let(:param) { nil }
+
+          it 'assigns an empty array to the instance variable' do
+            expect(command_line_builder.instance_variable_get(instance_var)).to eq([])
+          end
+        end
+      end
+
+      describe '.new' do
+        describe 'configuring lino' do
+          before { command_line_builder }
+
+          it 'creates a lino command line builder for the supplied binary' do
+            expect(Lino::CommandLineBuilder).to have_received(:for_command).with(binary)
+          end
+
+          it 'sets the lino command line builder option separator to be =' do
+            expect(lino_builder).to have_received(:with_option_separator).with('=')
+          end
+        end
+
+        context 'when the parsing the sub_commands' do
+          let(:builder_options) do
+            { binary: binary, sub_commands: param,
+              options: options, arguments: arguments }
+          end
+
+          it_behaves_like 'it ensures the instance variable is an array', :@sub_commands
+        end
+
+        context 'when the parsing the options' do
+          let(:builder_options) do
+            { binary: binary, sub_commands: sub_commands,
+              options: param, arguments: arguments }
+          end
+
+          it_behaves_like 'it ensures the instance variable is an array', :@options
+        end
+
+        context 'when the parsing the arguments' do
+          let(:builder_options) do
+            { binary: binary, sub_commands: sub_commands,
+              options: options, arguments: param }
+          end
+
+          it_behaves_like 'it ensures the instance variable is an array', :@arguments
+        end
+      end
+
+      describe '#build' do
+        before { command_line_builder.build }
+
+        it 'adds a Lino sub command for each command line command' do
+          expect(lino_builder).to have_received(:with_subcommand).with(sub_commands.first)
+        end
+
+        it 'associates Lino options with the last command line command' do
+          expect(lino_builder).to have_received(:with_subcommand).with(sub_commands.last)
+        end
+
+        it 'adds a Lino option/flag to the sub command for each command line option' do
+          expect(standard).to have_received(:add_to_subcommand).with(lino_subcommand_builder)
+        end
+
+        it 'adds a Lino argument to the sub command for each command line argument' do
+          expect(lino_builder).to have_received(:with_arguments).with([arguments])
+        end
+
+        it 'requests the Lino CommandLineBuilder build the command line  ' do
+          expect(lino_builder).to have_received(:build)
+        end
+
+        it 'returns the built command' do
+          expect(command_line_builder.build).to eq(built_command)
+        end
+      end
+    end
+  end
+end

--- a/spec/ruby_terraform/command_line/option/base_spec.rb
+++ b/spec/ruby_terraform/command_line/option/base_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require_relative '../../../../lib/ruby_terraform/command_line/option/base'
+
+module RubyTerraform
+  module CommandLine
+    module Option
+      describe Base do
+        subject(:option) { described_class.new(switch, value) }
+
+        let(:switch) { '-switch' }
+        let(:value) { 'option value' }
+        let(:sub) { instance_double(Lino::SubcommandBuilder) }
+
+        describe '.new' do
+          it 'uses a method to assign the option value to allow value setting to be overridden' do
+            expect(option.instance_variable_get(:@value)).to eq(value)
+          end
+        end
+
+        describe '#add_to_subcommand' do
+          it 'raises an error to inform subclasses of the need to override the method' do
+            expect { option.add_to_subcommand(sub) }.to raise_error(StandardError, 'not implemented')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ruby_terraform/command_line/option/boolean_spec.rb
+++ b/spec/ruby_terraform/command_line/option/boolean_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+require_relative '../../../../lib/ruby_terraform/command_line/option/boolean'
+
+module RubyTerraform
+  module CommandLine
+    module Option
+      describe Boolean do
+        subject(:option) { described_class.new(switch, value) }
+
+        let(:switch) { '-switch' }
+        let(:value) { true }
+        let(:sub) { instance_double(Lino::SubcommandBuilder) }
+        let(:add_to_subcommand) { option.add_to_subcommand(sub) }
+
+        before do
+          allow(sub).to receive(:with_option).and_return(sub)
+          add_to_subcommand
+        end
+
+        describe '.new' do
+          it_behaves_like 'an option that converts its value to a boolean'
+        end
+
+        describe '#add_to_subcommand' do
+          context 'when the option value is true' do
+            it 'adds the option=true to the terraform command line' do
+              expect(sub).to have_received(:with_option).with(switch, true)
+            end
+
+            context 'when the option value is false' do
+              let(:value) { false }
+
+              it 'adds the option=false to the terraform command line' do
+                expect(sub).to have_received(:with_option).with(switch, false)
+              end
+            end
+
+            context 'when the option value is nil' do
+              let(:value) { nil }
+
+              it 'calls with_option with the option key and value (where it is ignored)' do
+                expect(sub).to have_received(:with_option).with(switch, nil)
+              end
+            end
+
+            it 'returns the altered subcommand' do
+              expect(add_to_subcommand).to eq(sub)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ruby_terraform/command_line/option/flag_spec.rb
+++ b/spec/ruby_terraform/command_line/option/flag_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+require_relative '../../../../lib/ruby_terraform/command_line/option/flag'
+
+module RubyTerraform
+  module CommandLine
+    module Option
+      describe Flag do
+        subject(:option) { described_class.new(switch, value) }
+
+        let(:switch) { '-switch' }
+        let(:value) { true }
+        let(:sub) { instance_double(Lino::SubcommandBuilder) }
+        let(:add_to_subcommand) { option.add_to_subcommand(sub) }
+
+        before do
+          allow(sub).to receive(:with_flag).and_return(sub)
+          add_to_subcommand
+        end
+
+        describe '.new' do
+          it_behaves_like 'an option that converts its value to a boolean'
+        end
+
+        describe '#add_to_subcommand' do
+          context 'when the option value is true' do
+            it 'adds the switch to the terraform command line' do
+              expect(sub).to have_received(:with_flag).with(switch)
+            end
+
+            context 'when the option value is false' do
+              let(:value) { false }
+
+              it 'does not add the switch to the terraform command line' do
+                expect(sub).not_to have_received(:with_flag)
+              end
+            end
+
+            context 'when the option value is nil' do
+              let(:value) { nil }
+
+              it 'does not add the switch to the terraform command line' do
+                expect(sub).not_to have_received(:with_flag)
+              end
+            end
+
+            it 'returns the altered subcommand' do
+              expect(add_to_subcommand).to eq(sub)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ruby_terraform/command_line/option/standard_spec.rb
+++ b/spec/ruby_terraform/command_line/option/standard_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+require_relative '../../../../lib/ruby_terraform/command_line/option/standard'
+
+module RubyTerraform
+  module CommandLine
+    module Option
+      describe Standard do
+        subject(:option) { described_class.new(switch, value) }
+
+        let(:switch) { '-switch' }
+        let(:value) { 'some/state.tfstate' }
+        let(:sub) { instance_double(Lino::SubcommandBuilder) }
+        let(:add_to_subcommand) { option.add_to_subcommand(sub) }
+
+        before do
+          allow(JSON).to receive(:generate).and_call_original
+          allow(sub).to receive(:with_repeated_option).and_return(sub)
+          allow(sub).to receive(:with_option).and_return(sub)
+          add_to_subcommand
+        end
+
+        describe '#add_to_subcommand' do
+          it 'returns the altered subcommand' do
+            expect(add_to_subcommand).to eq(sub)
+          end
+
+          context 'when the option value is a single value' do
+            context 'when the option does not contain boolean values' do
+              context 'when the option value is populated / true' do
+                let(:value) { true }
+
+                it 'calls the SubcommandBuilder with_option with the switch and value' do
+                  expect(sub).to have_received(:with_option).with(switch, value)
+                end
+              end
+
+              context 'when the option value is false' do
+                let(:value) { false }
+
+                it 'does not call the SubcommandBuilder with_option' do
+                  expect(sub).not_to have_received(:with_repeated_option)
+                end
+              end
+
+              context 'when the option value is nil' do
+                let(:value) { nil }
+
+                it 'does not call the SubcommandBuilder with_option' do
+                  expect(sub).not_to have_received(:with_repeated_option)
+                end
+              end
+            end
+          end
+
+          context 'when the option value responds to keys' do
+            let(:value) { { key: 'value', another: 'value' } }
+
+            it 'calls the SubcommandBuilder with_repeated_option with the switch and an array key value pairs' do
+              expect(sub).to have_received(:with_repeated_option).with(
+                switch, %w['key=value' 'another=value'], anything # rubocop:disable Lint/PercentStringArray
+              )
+            end
+
+            it 'specifies the separator is a single space' do
+              expect(sub).to have_received(:with_repeated_option).with(
+                anything, anything, { separator: ' ' }
+              )
+            end
+
+            context 'when the values within the option value are not strings' do
+              let(:value) { { key: 123 } }
+
+              it 'uses JSON.generate to convert the value to a string' do
+                expect(JSON).to have_received(:generate).with(123)
+              end
+
+              it 'calls the SubcommandBuilder with_repeated_option with the switch and the converted value' do
+                expect(sub).to have_received(:with_repeated_option).with(
+                  switch, ["'key=123'"], anything
+                )
+              end
+            end
+          end
+
+          context 'when the option value responds to each' do
+            let(:value) { %w[some/state.tfstate another/state.tfstate] }
+
+            it 'calls the SubcommandBuilder with_repeated_option withthe switch and the array value' do
+              expect(sub).to have_received(:with_repeated_option).with(
+                switch,
+                %w[some/state.tfstate another/state.tfstate]
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ruby_terraform/command_line/option/switch_spec.rb
+++ b/spec/ruby_terraform/command_line/option/switch_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require_relative '../../../../lib/ruby_terraform/command_line/option/switch'
+
+module RubyTerraform
+  module CommandLine
+    module Option
+      describe Switch do
+        subject(:switch) { described_class.new(switch_string) }
+
+        let(:switch_string) { '-switch-string' }
+
+        describe '#to_s' do
+          context 'when the switch string starts with a -' do
+            it 'returns the supplied switch string' do
+              expect(switch.to_s).to eq('-switch-string')
+            end
+          end
+
+          context 'when the switch string does not start with a -' do
+            let(:switch_string) { 'switch-string' }
+
+            it 'returns the switch string prefixed with a -' do
+              expect(switch.to_s).to eq('-switch-string')
+            end
+          end
+        end
+
+        describe '#as_key' do
+          it 'returns the switch string converted to a hash key' do
+            expect(switch.as_key).to eq(:switch_string)
+          end
+        end
+
+        describe '#as_plural_key' do
+          it 'returns the switch string suffixed with an s converted to a hash key' do
+            expect(switch.as_plural_key).to eq(:switch_strings)
+          end
+        end
+
+        describe '#==' do
+          it 'returns true when compared to a string matching the switch_string' do
+            expect(switch == '-switch-string').to be_truthy
+          end
+
+          it 'returns true when compared to a string not matching the switch_string' do
+            expect(switch == '-different-switch').to be_falsey
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ruby_terraform/command_line/options_factory_spec.rb
+++ b/spec/ruby_terraform/command_line/options_factory_spec.rb
@@ -1,0 +1,118 @@
+require 'spec_helper'
+require_relative '../../../lib/ruby_terraform/command_line/options_factory'
+require_relative '../../../lib/ruby_terraform/command_line/option/standard'
+require_relative '../../../lib/ruby_terraform/command_line/option/flag'
+require_relative '../../../lib/ruby_terraform/command_line/option/boolean'
+
+module RubyTerraform
+  module CommandLine
+    describe OptionsFactory do
+      subject(:options) do
+        described_class.from(
+          values,
+          test_data.map { |_k, v| v[:switch] }.uniq
+        )
+      end
+      let(:test_data) do
+        { my_standard: { switch: '-my-standard', value: 'standard value',
+                         class: Option::Standard, option: standard },
+          my_boolean: { switch: '-my-boolean', value: true,
+                        class: Option::Boolean, option: boolean },
+          my_flag: { switch: '-my-flag', value: false,
+                     class: Option::Flag, option: flag },
+          my_plural: { switch: '-my-plural', value: 'value1',
+                       class: Option::Standard, option: singular },
+          my_plurals: { switch: '-my-plural', value: %w[value2 value3],
+                        class: Option::Standard, option: plural },
+          override: { switch: '-override', value: 'overridden value',
+                      class: Option::Standard, option: override } }
+      end
+      let(:values) do
+        values = test_data.transform_values { |v| v[:value] }
+        values[:option_key] = values.delete(:override)
+        values
+      end
+      let(:standard) { instance_double(Option::Standard) }
+      let(:flag) { instance_double(Option::Flag) }
+      let(:boolean) { instance_double(Option::Boolean) }
+      let(:singular) { instance_double(Option::Standard) }
+      let(:override) { instance_double(Option::Standard) }
+      let(:plural) { instance_double(Option::Standard) }
+
+      before do
+        stub_options(test_data)
+        stub_const(
+          'RubyTerraform::CommandLine::OptionsFactory::PLURAL_SWITCHES',
+          Set.new(['-my-plural'])
+        )
+        stub_const(
+          'RubyTerraform::CommandLine::OptionsFactory::BOOLEAN_SWITCHES',
+          Set.new(['-my-boolean'])
+        )
+        stub_const(
+          'RubyTerraform::CommandLine::OptionsFactory::FLAG_SWITCHES',
+          Set.new(['-my-flag'])
+        )
+        stub_const(
+          'RubyTerraform::CommandLine::OptionsFactory::OVERRIDE_SWITCHES',
+          { override: :option_key }
+        )
+        options
+      end
+
+      describe '.from' do
+        it 'creates a Standard Option with the singular switch and singular value for each plural option' do
+          expect(Option::Standard).to have_received(:new).with(
+            test_data[:my_plural][:switch], test_data[:my_plural][:value]
+          )
+        end
+
+        it 'creates a Standard Option with the singular switch and plural value for each plural option' do
+          expect(Option::Standard).to have_received(:new).with(
+            test_data[:my_plurals][:switch], test_data[:my_plurals][:value]
+          )
+        end
+
+        it 'creates a Boolean Option for each boolean switch' do
+          expect(Option::Boolean).to have_received(:new).with(
+            test_data[:my_boolean][:switch], test_data[:my_boolean][:value]
+          )
+        end
+
+        it 'creates a Flag Option each flag switch' do
+          expect(Option::Flag).to have_received(:new).with(
+            test_data[:my_flag][:switch], test_data[:my_flag][:value]
+          )
+        end
+
+        it 'uses the overridden option value when creating an overridden switch' do
+          expect(Option::Standard).to have_received(:new).with(
+            test_data[:override][:switch], test_data[:override][:value]
+          )
+        end
+
+        it 'creates a Standard Option for any other switches' do
+          expect(Option::Standard).to have_received(:new).with(
+            test_data[:my_standard][:switch], test_data[:my_standard][:value]
+          )
+        end
+
+        it 'returns the array of Options' do
+          expect(options).to eq([standard, boolean, flag, singular, plural, override])
+        end
+      end
+
+      def stub_options(test_data)
+        test_data.each_value do |config|
+          stub_option(
+            config[:class], config[:switch], config[:value], config[:option]
+          )
+        end
+      end
+
+      def stub_option(clazz, key, value, return_val)
+        allow(clazz).to receive(:new).with(key, value).and_return(return_val)
+      end
+    end
+  end
+end

--- a/spec/ruby_terraform/commands/apply_spec.rb
+++ b/spec/ruby_terraform/commands/apply_spec.rb
@@ -43,7 +43,7 @@ describe RubyTerraform::Commands::Apply do
 
   it_behaves_like 'a command with a boolean option', [terraform_command, :auto_approve, terraform_config_path]
 
-  it_behaves_like 'a command with an option', [terraform_command, :input, terraform_config_path]
+  it_behaves_like 'a command with a boolean option', [terraform_command, :input, terraform_config_path]
 
   it_behaves_like 'a command with an array option', [terraform_command, :targets, terraform_config_path]
 end

--- a/spec/ruby_terraform/commands/base_spec.rb
+++ b/spec/ruby_terraform/commands/base_spec.rb
@@ -1,0 +1,182 @@
+require 'spec_helper'
+
+class TestWith < RubyTerraform::Commands::Base
+  attr_reader :initialized
+
+  @initialized = false
+
+  def initialize_command
+    @initialized = true
+  end
+
+  def option_default_values(_values)
+    { default: 'value' }
+  end
+
+  def option_override_values(_values)
+    { sample: 'overridden' }
+  end
+
+  def sub_commands(_values)
+    'apply'
+  end
+
+  def switches
+    ['-sample']
+  end
+
+  def arguments(_values)
+    'an argument'
+  end
+end
+
+class TestWithout < RubyTerraform::Commands::Base
+  attr_reader :initialized
+
+  @initialized = false
+end
+
+module RubyTerraform
+  module Commands
+    describe Base do
+      subject(:base) { described_class.new(options) }
+
+      let(:options) do
+        {
+          binary: nil,
+          logger: nil,
+          stdin: nil,
+          stdout: nil,
+          stderr: nil
+        }
+      end
+      let(:configuration) do
+        instance_double(
+          RubyTerraform::Configuration,
+          binary: 'terraform',
+          logger: logger,
+          stdin: '',
+          stdout: $stdout,
+          stderr: $stderr
+        )
+      end
+      let(:logger) do
+        logger = Logger.new($stdout)
+        logger.level = Logger::INFO
+        logger
+      end
+      before do
+        allow(RubyTerraform).to receive(:configuration).and_return(configuration)
+      end
+
+      shared_examples 'an overridable parameter' do |parameter, value|
+        context "when no #{parameter} is supplied" do
+          before { base }
+
+          it 'uses the current value from the configuration' do
+            expect(configuration).to have_received(parameter)
+          end
+        end
+
+        context "when #{parameter} is supplied" do
+          before do
+            options[parameter] = value
+            base
+          end
+
+          it 'uses the supplied value' do
+            expect(configuration).not_to have_received(parameter)
+          end
+        end
+      end
+
+      describe '.new' do
+        it_behaves_like 'an overridable parameter', [:binary, 'terraform']
+
+        it_behaves_like 'an overridable parameter', [:logger, Logger.new($stdout)]
+
+        it_behaves_like 'an overridable parameter', [:stdin, '']
+
+        it_behaves_like 'an overridable parameter', [:stdout, $stdout]
+
+        it_behaves_like 'an overridable parameter', [:stderr, $stderr]
+
+        context 'when the subclass includes an initialize_command method' do
+          let(:subclass) { TestWith.new(options) }
+
+          it 'calls the method to initialize the subclass' do
+            expect(subclass.initialized).to be_truthy
+          end
+        end
+
+        context 'when the subclass does not include an initialize_command method' do
+          let(:subclass) { TestWithout.new(options) }
+
+          it 'calls the empty initialize_command in Base' do
+            expect(subclass.initialized).to be_falsey
+          end
+        end
+      end
+
+      describe '#execute' do
+        let(:opts) { { sample: 'provided' } }
+        let(:lino_commandline) { instance_double(Lino::CommandLine, execute: nil) }
+        let(:builder) { instance_double(RubyTerraform::CommandLine::Builder, build: lino_commandline) }
+        let(:subclass) { TestWith.new(options) }
+
+        before do
+          allow(RubyTerraform::CommandLine::Builder).to receive(:new).and_return(builder)
+          allow(RubyTerraform::CommandLine::OptionsFactory).to receive(:from).and_return([])
+
+          subclass.execute(opts)
+        end
+
+        it 'uses the OptionsFactory to compile the options to pass to Lino' do
+          expect(RubyTerraform::CommandLine::OptionsFactory).to have_received(:from)
+        end
+
+        it 'uses the Builder to supply the options to Lino' do
+          expect(RubyTerraform::CommandLine::Builder).to have_received(:new)
+        end
+
+        context 'when the subclass contains overrides for the Base defaults' do
+          it 'applies the subclass option defaults and overrides to the supplied options' do
+            expect(RubyTerraform::CommandLine::OptionsFactory).to have_received(:from).with({ default: 'value', sample: 'overridden' }, any_args)
+          end
+
+          it 'uses the subcommand provided by the subclass' do
+            expect(RubyTerraform::CommandLine::Builder).to have_received(:new).with(hash_including(sub_commands: 'apply'))
+          end
+
+          it 'uses the switches provided by the subclass' do
+            expect(RubyTerraform::CommandLine::OptionsFactory).to have_received(:from).with(any_args, ['-sample'])
+          end
+
+          it 'uses the arguments provided by the subclass' do
+            expect(RubyTerraform::CommandLine::Builder).to have_received(:new).with(hash_including(arguments: 'an argument'))
+          end
+        end
+
+        context 'when the subclass does not contain overrides for the Base defaults' do
+          let(:subclass) { TestWithout.new(options) }
+
+          it 'uses the empty option defaults and overrides provided by Base' do
+            expect(RubyTerraform::CommandLine::OptionsFactory).to have_received(:from).with({ sample: 'provided' }, any_args)
+          end
+
+          it 'uses the empty array of subcommands provided by Base' do
+            expect(RubyTerraform::CommandLine::Builder).to have_received(:new).with(hash_including(sub_commands: []))
+          end
+
+          it 'uses the empty array of switches provided by Base' do
+            expect(RubyTerraform::CommandLine::OptionsFactory).to have_received(:from).with(any_args, [])
+          end
+
+          it 'uses the empty array of arguments provided by Base' do
+            expect(RubyTerraform::CommandLine::Builder).to have_received(:new).with(hash_including(arguments: []))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ruby_terraform/commands/format_spec.rb
+++ b/spec/ruby_terraform/commands/format_spec.rb
@@ -28,9 +28,9 @@ describe RubyTerraform::Commands::Format do
 
   it_behaves_like 'a command with a flag', [terraform_command, :diff, terraform_config_path]
 
-  it_behaves_like 'a command with an option', [terraform_command, :list, terraform_config_path]
+  it_behaves_like 'a command with a boolean option', [terraform_command, :list, terraform_config_path]
 
   it_behaves_like 'a command with a flag', [terraform_command, :recursive, terraform_config_path]
 
-  it_behaves_like 'a command with an option', [terraform_command, :write, terraform_config_path]
+  it_behaves_like 'a command with a boolean option', [terraform_command, :write, terraform_config_path]
 end

--- a/spec/ruby_terraform/commands/get_spec.rb
+++ b/spec/ruby_terraform/commands/get_spec.rb
@@ -20,7 +20,7 @@ describe RubyTerraform::Commands::Get do
 
   it_behaves_like 'a command without a binary supplied', [terraform_command, described_class, terraform_config_path]
 
-  it_behaves_like 'a command with an option', [terraform_command, :update, terraform_config_path]
+  it_behaves_like 'a command with a flag', [terraform_command, :update, terraform_config_path]
 
   it_behaves_like 'a command with a flag', [terraform_command, :no_color, terraform_config_path]
 end

--- a/spec/ruby_terraform/commands/init_spec.rb
+++ b/spec/ruby_terraform/commands/init_spec.rb
@@ -19,7 +19,7 @@ describe RubyTerraform::Commands::Init do
 
   it_behaves_like 'a command with a flag', [terraform_command, :no_color]
 
-  it_behaves_like 'a command with an option', [terraform_command, :force_copy]
+  it_behaves_like 'a command with a flag', [terraform_command, :force_copy]
 
   it_behaves_like 'a command with a map option', [terraform_command, :backend_config]
 

--- a/spec/ruby_terraform/commands/plan_spec.rb
+++ b/spec/ruby_terraform/commands/plan_spec.rb
@@ -73,7 +73,7 @@ describe RubyTerraform::Commands::Plan do
 
   it_behaves_like 'a command with an array option', [terraform_command, :var_files, terraform_config_path]
 
-  it_behaves_like 'a command with an option', [terraform_command, :input, terraform_config_path]
+  it_behaves_like 'a command with a boolean option', [terraform_command, :input, terraform_config_path]
 
   it_behaves_like 'a command with an array option', [terraform_command, :targets, terraform_config_path]
 

--- a/spec/ruby_terraform/commands/refresh_spec.rb
+++ b/spec/ruby_terraform/commands/refresh_spec.rb
@@ -22,7 +22,7 @@ describe RubyTerraform::Commands::Refresh do
 
   it_behaves_like 'a command that accepts vars', [terraform_command, terraform_config_path]
 
-  it_behaves_like 'a command with an option', [terraform_command, :input, terraform_config_path]
+  it_behaves_like 'a command with a boolean option', [terraform_command, :input, terraform_config_path]
 
   it_behaves_like 'a command with an option', [terraform_command, :state, terraform_config_path]
 

--- a/spec/ruby_terraform/commands/remote_config_spec.rb
+++ b/spec/ruby_terraform/commands/remote_config_spec.rb
@@ -17,7 +17,7 @@ describe RubyTerraform::Commands::RemoteConfig do
 
   it_behaves_like 'a command without a binary supplied', [terraform_command, described_class]
 
-  it_behaves_like 'a command with an option', [terraform_command, :backend]
+  it_behaves_like 'a command with a boolean option', [terraform_command, :backend]
 
   it_behaves_like 'a command with a map option', [terraform_command, :backend_config]
 

--- a/spec/support/shared/a_command_with_an_option.rb
+++ b/spec/support/shared/a_command_with_an_option.rb
@@ -1,11 +1,10 @@
 shared_examples 'a command with an option' do |command, option, directory = nil, switch_override: nil|
   switch = if switch_override.nil?
-             "-#{option.to_s.sub('_',
-                                 '-')}"
+             "-#{option.to_s.sub('_', '-')}"
            else
              switch_override
            end
-  switch_value = 'true'
+  switch_value = 'option-value'
   argument = directory.nil? ? nil : " #{directory}"
 
   it_behaves_like 'a valid command line', {

--- a/spec/support/shared/an_option_that_converts_its_value_to_boolean.rb
+++ b/spec/support/shared/an_option_that_converts_its_value_to_boolean.rb
@@ -1,0 +1,41 @@
+shared_examples 'an option that converts its value to a boolean' do
+  context 'when the value is nil' do
+    let(:value) { nil }
+
+    it 'sets the option value to nil' do
+      expect(option.instance_variable_get(:@value)).to be_nil
+    end
+  end
+
+  context 'when the value is true' do
+    let(:value) { true }
+
+    it 'sets the option value to true' do
+      expect(option.instance_variable_get(:@value)).to be_truthy
+    end
+  end
+
+  context "when the value is 'true'" do
+    let(:value) { 'true' }
+
+    it 'sets the option value to true' do
+      expect(option.instance_variable_get(:@value)).to be_truthy
+    end
+  end
+
+  context 'when the value is false' do
+    let(:value) { false }
+
+    it 'sets the option value to false' do
+      expect(option.instance_variable_get(:@value)).to be_falsey
+    end
+  end
+
+  context 'when the value is not true/false or a string starting with T' do
+    let(:value) { 'unknown' }
+
+    it 'sets the option value to false' do
+      expect(option.instance_variable_get(:@value)).to be_falsey
+    end
+  end
+end

--- a/spec/support/shared/import_class_shared_examples.rb
+++ b/spec/support/shared/import_class_shared_examples.rb
@@ -56,7 +56,7 @@ shared_examples 'an import command with a boolean option' do |opt_key|
 
   it_behaves_like 'a valid command line', {
     reason: "does not include #{switch}=false when the #{opt_key} option is false",
-    expected_command: "terraform import -config=#{common_options[:directory]} #{common_options[:address]} #{common_options[:id]}",
+    expected_command: "terraform import -config=#{common_options[:directory]} #{switch}=false #{common_options[:address]} #{common_options[:id]}",
     options: common_options.merge({ opt_key => false })
   }
 end


### PR DESCRIPTION
As mentioned in the earlier RFC I've bounced around a bit on how best to do this.  I settled on each command listing the switches it accepts, and having an OptionsFactory that knows what all the switches are and what sort of option it should create for each (flag, boolean or standard).  This does of course assume Terraform is consistent with its switches but from what I've seen so far that appears to be the case (and saves having to incorporate the option specialisation into each command).

I have a follow up PR that updates all the commands to reflect the switches they accept in Terraform 0.15 but as this one was already pretty massive I thought I'd split it out at the point where the commands are still largely "the same" as they were before I started.

I've made some notes in the second commit about the small changes I had to make in the specs to make this work.  Hopefully it all makes sense.

The last commit is just a minor fix to `output` and a change to the `rubocop.yml` to get a clean bill of health from rubocop :-)