### PR TITLE
Add Support for the `-migrate-state` flag in `terraform init`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+IMPROVEMENTS:
+
+* Add support for `-migrate-state` flag to `RubyTerraform::Commands::Init`
+
 ## 1.7.0 (December 27th 2022)
 
 IMPROVEMENTS:

--- a/lib/ruby_terraform/commands/init.rb
+++ b/lib/ruby_terraform/commands/init.rb
@@ -49,6 +49,8 @@ module RubyTerraform
     #   (deprecated, removed in terraform 0.15).
     # * +:lock_timeout+: the duration to retry a state lock; defaults to +"0s"+;
     #   (deprecated, removed in terraform 0.15).
+    # * +:migrate_state+: if set, attempts to reconfigure a backend and attempt
+    #   to migrate any existing state
     # * +:no_color+: whether or not the output from the command should be in
     #   color; defaults to +false+.
     # * +:plugin_dir+: the path to a directory containing plugin binaries; this
@@ -104,6 +106,7 @@ module RubyTerraform
           -input
           -lock
           -lock-timeout
+          -migrate-state
           -no-color
           -plugin-dir
           -reconfigure

--- a/lib/ruby_terraform/options/definitions.rb
+++ b/lib/ruby_terraform/options/definitions.rb
@@ -61,6 +61,7 @@ module RubyTerraform
           -force-copy
           -ignore-remote-version
           -json
+          -migrate-state
           -no-color
           -raw
           -reconfigure

--- a/spec/ruby_terraform/commands/init_spec.rb
+++ b/spec/ruby_terraform/commands/init_spec.rb
@@ -70,6 +70,11 @@ describe RubyTerraform::Commands::Init do
 
   it_behaves_like(
     'a command with a flag',
+    described_class, 'init', :migrate_state
+  )
+
+  it_behaves_like(
+    'a command with a flag',
     described_class, 'init', :no_color
   )
 


### PR DESCRIPTION
This flag appears to be missing from support, so I've added it.